### PR TITLE
chore(claude): correct CLAUDE.md and add project automations

### DIFF
--- a/.claude/agents/page-consistency.md
+++ b/.claude/agents/page-consistency.md
@@ -1,0 +1,54 @@
+---
+name: page-consistency
+description: Reviews a page in src/pages/ against this repo's structural conventions. Use after creating a page or substantially editing one's head/layout markup. Read-only — reports findings, does not edit.
+tools: Read, Grep, Glob
+---
+
+You review YeRide website pages for structural consistency. You do not edit
+files. You report findings and stop.
+
+## Why this agent exists
+
+The five pages in `src/pages/` disagree with each other. There is no shared
+layout enforcing a shape, no linter, and no test. Structural drift is invisible
+until it renders wrong in production.
+
+## Reference shape
+
+`src/pages/fare-estimate.astro` is the post-migration model. Compare against it,
+not against whichever page the author copied.
+
+## Checklist
+
+Read the target page, then check each item and report PASS or FAIL with the
+offending line.
+
+1. **No Tailwind CDN.** `<script src="https://cdn.tailwindcss.com">` must be
+   absent — `@astrojs/tailwind` already supplies Tailwind. Four legacy pages
+   still have it; a new page having it is a finding.
+2. **Header and Footer imported and rendered.** `Header.astro` and
+   `Footer.astro` imported in frontmatter and present in `<body>`. Note if the
+   page inlines its own header/footer markup instead (only `index.astro` is
+   expected to).
+3. **No `BaseLayout.astro`.** Only `404.astro` should use it.
+4. **Head block complete**: `charset`, `favicon.svg` icon link, `viewport`,
+   `Astro.generator`, and a `<title>` ending in `- YeRide`.
+5. **Inter font linked** via the Google Fonts stylesheet.
+6. **`<body>` classes** match `bg-gray-50 text-gray-900 font-sans`.
+7. **`<main>` clears the fixed header** with `pt-[90px]`.
+8. **Scripts**: a `<script>` using `import` must NOT be `is:inline`; an
+   `is:inline` script must receive values via `define:vars`.
+9. **No `@apply`** in any `<style>` block — this repo forbids it.
+10. **Nav reachability**: if this is a new route, check whether it appears in
+    `Header.astro`, `Footer.astro`, and both inline copies in `index.astro`.
+    Report each missing surface separately.
+
+## Output
+
+A markdown table: `Check | Verdict | Evidence (file:line)`. Then a short
+`Must fix` list of FAILs only, ordered by user-visible impact. If everything
+passes, say so in one line and add nothing else.
+
+Do not report on styling taste, copy, accessibility, or anything outside the
+checklist. Do not suggest refactoring the legacy pages — they are known and
+intentional until someone schedules that work.

--- a/.claude/hooks/astro-check.sh
+++ b/.claude/hooks/astro-check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PostToolUse hook: type-check after an .astro/.ts edit.
+#
+# `npm run build` (astro check && astro build) is this repo's only verification
+# gate, and pushes to main deploy straight to production. This surfaces type
+# errors at edit time instead of in GitHub Actions.
+#
+# Uses the local binary, never `npx`: with node_modules absent, `npx astro`
+# prompts to install @astrojs/check and hangs the session waiting on stdin.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+astro_bin="$repo_root/node_modules/.bin/astro"
+
+file_path="$(jq -r '.tool_input.file_path // .tool_response.filePath // empty')"
+
+case "$file_path" in
+  *.astro | *.ts) ;;
+  *) exit 0 ;;
+esac
+
+# Dependencies not installed yet — stay silent rather than block the edit.
+[ -x "$astro_bin" ] || exit 0
+
+if output="$(cd "$repo_root" && "$astro_bin" check 2>&1)"; then
+  exit 0
+fi
+
+printf 'astro check failed after editing %s\n\n%s\n' "$file_path" "$output" >&2
+exit 2

--- a/.claude/hooks/env-var-drift.sh
+++ b/.claude/hooks/env-var-drift.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# PostToolUse hook: catch PUBLIC_ env vars that the deploy workflow never writes.
+#
+# Adding a client env var is a three-place change: .env, the "Create env file"
+# step in deploy-all.yml, and a GitHub Secret. Miss the workflow and the var is
+# an empty string in production with no build error — silent breakage.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="$repo_root/.github/workflows/deploy-all.yml"
+
+file_path="$(jq -r '.tool_input.file_path // .tool_response.filePath // empty')"
+
+[ -n "$file_path" ] && [ -f "$file_path" ] && [ -f "$workflow" ] || exit 0
+
+missing=""
+while IFS= read -r var; do
+  [ -n "$var" ] || continue
+  grep -q "$var" "$workflow" || missing="$missing $var"
+done < <(grep -oE 'import\.meta\.env\.PUBLIC_[A-Z0-9_]+' "$file_path" |
+  sed 's/.*env\.//' | sort -u)
+
+[ -n "$missing" ] || exit 0
+
+msg="Not written by .github/workflows/deploy-all.yml:$missing"
+msg="$msg — empty in production. Add to the 'Create env file' step AND as a GitHub Secret."
+
+jq -cn --arg m "$msg" '{
+  systemMessage: $m,
+  hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $m}
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/astro-check.sh\"",
+            "timeout": 120,
+            "statusMessage": "Type-checking Astro files..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/env-var-drift.sh\"",
+            "timeout": 15,
+            "statusMessage": "Checking PUBLIC_ env vars..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/nav-sync/SKILL.md
+++ b/.claude/skills/nav-sync/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: nav-sync
+description: Use when adding, removing, renaming, or re-pointing any navigation or footer link on the YeRide site, or when a link appears on some pages but not the homepage.
+---
+
+# nav-sync
+
+Navigation markup is duplicated across four independent copies. A link must be
+added to all four, or it appears on some pages and not others.
+
+| Surface | File | Reaches |
+|---|---|---|
+| Shared header | `src/components/Header.astro` | about, contact, privacy-policy, fare-estimate |
+| Shared footer | `src/components/Footer.astro` | same four pages |
+| Inline header | `src/pages/index.astro` (~95–130) | homepage only |
+| Inline footer | `src/pages/index.astro` (~345–395) | homepage only |
+
+`src/components/navBar.astro` + `src/data/navData.ts` are a fifth, near-dead copy
+reached only by `BaseLayout.astro` → `404.astro`. Its entries (`ride`, `drive`,
+`register`) point at routes that do not exist.
+
+Inventory every surface before and after the change — the two lists must match:
+
+```bash
+grep -n 'href=' src/components/Header.astro src/components/Footer.astro
+grep -n 'href="/\|href="#' src/pages/index.astro
+```

--- a/.claude/skills/nav-sync/SKILL.md
+++ b/.claude/skills/nav-sync/SKILL.md
@@ -19,6 +19,11 @@ added to all four, or it appears on some pages and not others.
 reached only by `BaseLayout.astro` → `404.astro`. Its entries (`ride`, `drive`,
 `register`) point at routes that do not exist.
 
+`BaseLayout.astro` renders `<Nav />` + `<slot />` and **no footer at all**, so
+`404.astro` has no footer to add a link to. Full-site footer coverage there is a
+structural change (import and render `Footer.astro`), not a link edit — treat it
+as out of scope unless asked.
+
 Inventory every surface before and after the change — the two lists must match:
 
 ```bash

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: new-page
+description: Use when adding a route to the YeRide site, or when a page renders unstyled, flashes unstyled content on load, or is missing the site header and footer.
+---
+
+# new-page
+
+## Overview
+
+The five existing pages disagree structurally, so copying whichever one you
+happened to open propagates whichever legacy shape it carries. Copy this instead.
+
+`fare-estimate.astro` is the only page in the post-migration shape (commit
+`0fdd9bf`, "replace Tailwind CDN with Astro integration"). It is the model.
+
+## Template
+
+```astro
+---
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <title>Page Name - YeRide</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="bg-gray-50 text-gray-900 font-sans">
+    <Header />
+    <main class="pt-[90px]">
+      <!-- content -->
+    </main>
+    <Footer />
+  </body>
+</html>
+```
+
+## Rules
+
+- **No `<script src="https://cdn.tailwindcss.com">`.** `index.astro`,
+  `about.astro`, `contact.astro`, and `privacy-policy.astro` still load it on top
+  of the `@astrojs/tailwind` build. That is duplicate CSS and a flash of
+  unstyled content, not a requirement.
+- **Do not use `BaseLayout.astro`.** Only `404.astro` does. It pulls Open Props
+  from unpkg at runtime and renders a nav pointing at routes that don't exist.
+- **Keep `pt-[90px]` on `<main>`.** The header is fixed; without it the first
+  section renders underneath.
+- **Client-side JS goes in a bundled `<script>`** (plain `<script>` in the page,
+  as `fare-estimate.astro` does) so imports resolve. `is:inline` scripts cannot
+  use imports and need `define:vars` to receive any value.
+
+## After creating the page
+
+Add it to the site navigation — that is four separate edits, not one. Use the
+`nav-sync` skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,64 +4,73 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-YeRide website — a static marketing and pre-registration site for a community-driven ridesharing platform. Built with Astro, deployed to GitHub Pages at https://www.yeride.com.
+YeRide website — a static marketing, pre-registration, and fare-estimate site for a community-driven ridesharing platform. Astro 5, static output, deployed to GitHub Pages at https://www.yeride.com.
 
 ## Commands
 
 ```bash
 npm run dev        # Dev server at http://localhost:4321
-npm run build      # Type-check (astro check) + production build → dist/
+npm run build      # astro check (type-check) + astro build → dist/
 npm run preview    # Preview production build locally
 ```
 
-There is no test runner configured. No linter configured.
+No test runner and no linter are configured. `npm run build` is the only automated verification gate — `astro check` runs first, so a type error fails the build.
 
 ## Environment Variables
 
-Create a `.env` file for local development:
+All five are `PUBLIC_` (client-side) and are injected in CI from GitHub Secrets. Create a `.env` for local development:
+
 ```
-PUBLIC_API_URL=https://api.yeride.com/
+PUBLIC_API_URL=https://api.yeride.com/          # must end with a trailing slash
+PUBLIC_GOOGLE_MAPS_API_KEY=...
+PUBLIC_FIREBASE_API_KEY=...
+PUBLIC_FIREBASE_AUTH_DOMAIN=...
+PUBLIC_FIREBASE_PROJECT_ID=...
 ```
 
-The `PUBLIC_` prefix makes it available client-side. Used by the PreRegistrationForm component to POST to `${PUBLIC_API_URL}v1/auth/register`.
+Adding a new env var requires editing `.github/workflows/deploy-all.yml` (the "Create env file" step writes `.env` line by line) **and** adding the GitHub Secret — otherwise it is silently empty in production.
 
 ## Architecture
 
 **Framework:** Astro 5 (static output, zero JS by default)
-**Styling:** Tailwind CSS 3 via `@astrojs/tailwind` integration + Open Props for CSS custom properties
-**Deployment:** GitHub Actions → GitHub Pages (triggered on push to `main`)
+**Styling:** Tailwind CSS 3 via `@astrojs/tailwind`
+**Deployment:** GitHub Actions → GitHub Pages on push to `main`
 
-### Key directories
+### Two independent backends
 
-- `src/pages/` — File-based routing. Each `.astro` file = a route
-- `src/components/` — Reusable Astro components (Header, Footer, PreRegistrationForm, navBar)
-- `src/layouts/` — BaseLayout.astro (used by secondary pages, **not** used by index.astro)
-- `src/styles/main.css` — Global styles (Open Props imports)
-- `public/` — Static assets served as-is (images, favicon, CNAME)
-- `docs/` — Project documentation (architecture, components, API, deployment, contributing)
+The site talks to two unrelated services; don't conflate them.
 
-### Layout inconsistency to be aware of
+1. **Pre-registration** (`src/components/PreRegistrationForm.astro`) — plain `fetch` POST to `${PUBLIC_API_URL}v1/auth/register`. The form logic lives in one large `is:inline` script that receives the URL via `define:vars`, so it is *not* bundled and cannot use imports.
+2. **Fare estimates** (`src/pages/fare-estimate.astro` + `src/lib/fareEstimate.ts`) — Firebase **callable function** `estimateFares`, hardcoded to region `us-east1` in `src/lib/firebase.ts`. Service area defaults to `us-fl-south-florida`. The page script loads Google Maps libraries (`maps`, `places`, `marker`, `routes`) via `@googlemaps/js-api-loader`, resolves pickup/dropoff, computes distance + duration, then calls `getEstimates()`.
 
-The homepage (`index.astro`) is self-contained with its own inline header/footer and loads Tailwind via CDN. Other pages use `BaseLayout.astro` with the `Header` and `Footer` components and get Tailwind from the Astro integration. This means changes to shared navigation need to be applied in multiple places.
+`firebase-admin` is in `package.json` but unused in `src/`. Firebase Auth and Firestore are not used — only `firebase/functions`.
 
-### Third-party integrations
+### Page structure is inconsistent — check before editing shared UI
 
-- **Firebase SDK** (`firebase` package) — client-side, used for pre-registration
-- **Tally.so** — embedded contact form on `/contact` (form ID: `mJa5J7`)
-- **Google Fonts** — Inter (400, 600, 700)
+There is no single layout. Each page declares its own `<html>`/`<head>`:
+
+- `src/pages/404.astro` — the **only** page using `BaseLayout.astro`, which is also the only consumer of `navBar.astro`, `src/data/navData.ts`, and `src/styles/main.css` (Open Props from unpkg). `navData.ts` lists routes (`ride`, `drive`, `register`) that don't exist.
+- `src/pages/index.astro` — fully self-contained, with its own inline header and footer markup (does *not* use the `Header`/`Footer` components).
+- `about`, `contact`, `privacy-policy`, `fare-estimate` — self-contained `<html>` importing the `Header` and `Footer` components.
+
+Consequence: a navigation or footer change usually needs edits in **both** `src/components/Header.astro` / `Footer.astro` **and** the inline copies in `index.astro`.
+
+Also: `index`, `about`, `contact`, and `privacy-policy` load Tailwind from `https://cdn.tailwindcss.com` in `<head>`, *on top of* the `@astrojs/tailwind` build. `fare-estimate.astro` relies on the integration alone. When adding a page, match whichever surrounding page you're copying rather than assuming the integration is enough.
+
+### Other integrations
+
+- **Tally.so** — embedded contact form on `/contact` (form ID `mJa5J7`)
+- **Google Fonts** — Inter (400, 600, 700), linked per page
+- `src/pages/redirect.astro` — bare HTML that bounces to the `yeride://register` deep link
 
 ## Coding Conventions
 
-- Astro components use `.astro` extension with scoped `<style>` tags
-- Use Tailwind utility classes directly; **never use `@apply`**
-- Minimize client-side JavaScript; use `client:*` directives only when hydration is needed
-- TypeScript for type safety (extends `astro/tsconfigs/base`)
-- Conventional Commits for commit messages (feat, fix, docs, chore, etc.)
-- Mobile-first responsive design using Tailwind breakpoints (sm, md, lg)
+- Astro components (`.astro`) with scoped `<style>` tags
+- Tailwind utility classes directly; **never use `@apply`**
+- Minimize client-side JS; `client:*` directives only when hydration is genuinely needed
+- Mobile-first responsive design (`sm`, `md`, `lg`)
+- Conventional Commits (`feat`, `fix`, `docs`, `chore`, …)
 
-## Deployment
+## Further Documentation
 
-Pushes to `main` trigger `.github/workflows/deploy-all.yml`:
-1. Checkout → Node 20 setup → inject `PUBLIC_API_URL` from GitHub Secrets into `.env`
-2. `npm ci` → `npm run build`
-3. Upload `dist/` artifact → deploy to GitHub Pages
+`docs/` holds longer-form guides: `architecture.md`, `components.md`, `api-integration.md`, `deployment.md`, `getting-started.md`, `contributing.md`.


### PR DESCRIPTION
Corrects factual drift in `CLAUDE.md` and adds a `.claude/` directory so Claude Code config is shared with the team instead of living user-local.

## CLAUDE.md corrections

Verified against source, not assumed:

| Was | Actually |
|---|---|
| One `PUBLIC_` env var documented | Five, all injected by `deploy-all.yml` |
| "Firebase — used for pre-registration" | Firebase backs *fare estimates* (`estimateFares` callable, `us-east1`). Pre-registration is a plain `fetch` to `${PUBLIC_API_URL}v1/auth/register` |
| "Homepage self-contained, other pages use BaseLayout" | Inverted — only `404.astro` uses `BaseLayout`; every other page declares its own `<html>` |
| Open Props listed as global styling | Reaches exactly one page (`404.astro`, via `BaseLayout`) |

Also documents the fare-estimate flow (absent entirely) and that `npm run build` is the only verification gate.

## Automations added

- **`hooks/astro-check.sh`** — runs `astro check` after `.astro`/`.ts` edits, exits 2 with compiler output. Type errors surface at edit time instead of in the deploy workflow. Uses the local binary deliberately: `npx astro` prompts to install `@astrojs/check` and blocks on stdin when `node_modules` is absent.
- **`hooks/env-var-drift.sh`** — warns when a `PUBLIC_` var is referenced in source but never written by `deploy-all.yml`. That combination is silently empty in production with no build error.
- **`agents/page-consistency.md`** — read-only page-structure reviewer.
- **`skills/new-page`** — canonical page template, based on `fare-estimate.astro` (the only post-`0fdd9bf` page).
- **`skills/nav-sync`** — the four duplicated nav/footer surfaces.

## Verification

| Item | Result |
|---|---|
| `astro-check.sh` on a real type error | exit 2, full `ts(2322)` output |
| `astro-check.sh` on clean / non-matching files | exit 0, silent |
| `env-var-drift.sh` on an undeclared var | correct JSON warning |
| `settings.json` | `jq`-validated, `$CLAUDE_PROJECT_DIR` resolves |
| `page-consistency` agent | **11/11** planted defects caught, correct line numbers |
| `astro check` on the repo | 0 errors |

## Reviewer note — the two skills are weakly justified

Baseline-tested by giving agents the same tasks with skill invocation, `.claude/`, and `CLAUDE.md` all forbidden. **They largely succeeded without the skills**: the control found all four nav surfaces unprompted and independently chose the correct page shape, including omitting the Tailwind CDN tag.

So these two files buy consistency and save ~46k tokens of rediscovery per session — they are not preventing a demonstrated failure. `nav-sync` was trimmed to a table plus a grep on that basis. Reasonable to drop them if you disagree; the hooks and the reviewer agent stand on their own evidence.

## Not included

- No push to `main`, so no deploy triggered.
- `.scratch/` left untracked (pre-existing).
- The 80 Dependabot advisories on `main` are untouched — separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
