### PR TITLE
ci: update actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
GitHub is force-running our Node 20 actions on Node 24 and warning about it. This bumps to the majors that target Node 24 natively.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

`actions/upload-artifact@v4` appeared in the warning but isn't in our workflow — it comes in transitively via `upload-pages-artifact@v3`. Bumping that to v5 pulls `upload-artifact@v7`.

## Breaking changes checked

Release notes reviewed for every major crossed, not assumed:

- **`setup-node` v6** — *"Limit automatic caching to npm."* This workflow already sets `cache: 'npm'` explicitly, so no impact.
- **`checkout` v5** — requires runner ≥ v2.327.1. GitHub-hosted runners are well past this.
- **`checkout` v7** — blocks fork checkouts for `pull_request_target` / `workflow_run`. This workflow triggers on `push` and `workflow_dispatch` only.
- Remaining majors are Node-runtime bumps, ESM migrations, and dependency updates.

## Verification

- YAML re-parsed after edit; both jobs and all four `uses:` resolve.
- All four moving major tags confirmed to exist against the GitHub API.
- `npm run build` passes locally — 7 pages, 0 type errors.

**What I could not verify:** the workflow itself. It only runs on push to `main`, and `workflow_dispatch` on this branch would deploy to the live Pages environment. The first real execution of these action versions will be the deploy triggered by merging this. The diff is four version strings with no structural change, but that is the honest limit of pre-merge testing here.

## Deliberately not included

`node-version` stays at `'20'` for the build. That is a **separate and arguably more urgent problem** — Node 20 reached end-of-life in April 2026, so the build toolchain gets no security patches. Local dev is on v22.14.0 and the build passes there, so bumping CI to `'22'` would restore parity and is low risk. Left out to keep this PR to the reported warning; happy to add it here or in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
