### PR TITLE
ci: build on Node 24 instead of end-of-life Node 20

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Create env file


### PR DESCRIPTION
One-line change: `node-version: '20'` → `'24'`.

Node 20 reached **end of life in April 2026**, so the build toolchain has been running on a runtime that no longer receives security patches.

This is a **different problem** from the actions-runtime bump in #27. That fixed the Node version the *actions themselves* execute on, which GitHub warns about. This is the Node version that *builds the site* — GitHub does not warn about it, which is why it went unnoticed.

## Why 24

Node 24 is the current **Active LTS**, supported until **April 2028**, and matches the Node 24 runtime the runner already uses for actions after #27.

This PR originally targeted Node 22 on the grounds that it matched local dev (v22.14.0). That was the weaker choice: Node 22 entered maintenance in October 2025 and EOLs April 2027, so it would have bought roughly 9 months before needing this again. Retargeted to 24 deliberately.

**Consequence worth accepting knowingly:** CI now runs a newer major than local dev until developer machines move to 24. For a static Astro build with no native modules that is low risk, but it is a real divergence — bumping local environments to 24 is the natural follow-up.

## Verification

Not asserted — actually run. Node 24 was installed via nvm and the full CI sequence executed:

- `node --version` → **v24.18.0**, npm 11.16.0
- `rm -rf node_modules dist && npm ci && npm run build` → **7 pages, 0 type errors**
- `dist/` complete: all 7 HTML pages, `_astro` assets, `images/`, `favicon.svg`, and `CNAME` intact (`yeride.com` / `www.yeride.com`)
- Astro 5 declares `node: '18.20.8 || ^20.3.0 || >=22.0.0'` — 24 is in range
- Workflow YAML re-parsed after the edit

## One behavioural difference to know about

Node 24 ships **npm 11**, where Node 22 ships npm 10. npm 11 withholds dependency install scripts by default and prints:

```
npm warn allow-scripts
npm warn Run `npm approve-scripts --allow-scripts-pending` to review
```

The build is unaffected — no dependency in this project needs install scripts, and `dist/` is byte-complete. Flagging it because the warning will appear in CI logs and could matter if a future dependency does require a postinstall step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
