### PR TITLE
fix: reduce CNAME to the single canonical domain

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,2 +1,1 @@
-yeride.com
 www.yeride.com


### PR DESCRIPTION
`public/CNAME` held **two** domains, separated by a **CRLF**, with no trailing newline:

```
yeride.com\r\nwww.yeride.com
```

GitHub Pages expects exactly one domain in this file, and it **rewrites the repo's custom-domain setting from this file on every deploy**. A malformed value risks resetting or confusing the Pages config — which matters right now, because the DNS cutover from Vercel to GitHub Pages is in progress and this file determines what Pages considers canonical when the records land.

## The change

```diff
-yeride.com
-www.yeride.com
\ No newline at end of file
+www.yeride.com
```

One domain, LF line ending, trailing newline. 15 bytes.

## Why `www` and not the apex

The Pages API already reports `cname: www.yeride.com`, so that is the canonical host today — this makes the file agree with the live setting rather than changing it. **This is a no-op for the current Pages config**, which is what makes it safe to land before the DNS change.

The apex is unaffected: once `yeride.com`'s A records point at `185.199.108–111.153`, GitHub serves the apex and 301s it to the canonical `www.yeride.com`. Standard Pages behaviour.

## Verification

- New file is exactly `www.yeride.com\n` — confirmed with `od -c`, 15 bytes
- `npm run build` copies it to `dist/CNAME` **byte-for-byte identical**
- Build green: 7 pages, 0 type errors

## Context

Part of restoring `www.yeride.com` to this Astro site. The domain is currently served by the `yeride-admin` Vercel project, which has no `/contact`, `/about`, `/fare-estimate`, or `/privacy-policy` routes — all four 404 today. Notably `https://www.yeride.com/contact/` is the **App Store Connect Support URL**, registered to resolve a Guideline 1.5 rejection, and it is currently dead.

`admin.yeride.com` has already been attached to the `yeride-admin` project and verified, so the admin app has a permanent home before the domain moves.

Land this before repointing DNS at GoDaddy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
