### PR TITLE
feat(fees): /fees + /es/fees on the live fee schedule

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -34,6 +34,7 @@ jobs:
           echo "PUBLIC_FIREBASE_API_KEY=${{ secrets.PUBLIC_FIREBASE_API_KEY }}" >> .env
           echo "PUBLIC_FIREBASE_AUTH_DOMAIN=${{ secrets.PUBLIC_FIREBASE_AUTH_DOMAIN }}" >> .env
           echo "PUBLIC_FIREBASE_PROJECT_ID=${{ secrets.PUBLIC_FIREBASE_PROJECT_ID }}" >> .env
+          echo "PUBLIC_FEE_SCHEDULE_URL=${{ secrets.PUBLIC_FEE_SCHEDULE_URL }}" >> .env
 
       - name: Install dependencies
         # NPM_TOKEN: org read-only classic PAT with read:packages — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ No test runner and no linter are configured. `npm run build` is the only automat
 
 ## Environment Variables
 
-All five are `PUBLIC_` (client-side) and are injected in CI from GitHub Secrets. Create a `.env` for local development:
+All six are `PUBLIC_` (client-side) and are injected in CI from GitHub Secrets. Create a `.env` for local development:
 
 ```
 PUBLIC_API_URL=https://api.yeride.com/          # must end with a trailing slash
@@ -26,6 +26,7 @@ PUBLIC_GOOGLE_MAPS_API_KEY=...
 PUBLIC_FIREBASE_API_KEY=...
 PUBLIC_FIREBASE_AUTH_DOMAIN=...
 PUBLIC_FIREBASE_PROJECT_ID=...
+PUBLIC_FEE_SCHEDULE_URL=...                     # public getFeeSchedule endpoint (/fees)
 ```
 
 Adding a new env var requires editing `.github/workflows/deploy-all.yml` (the "Create env file" step writes `.env` line by line) **and** adding the GitHub Secret — otherwise it is silently empty in production.

--- a/src/components/FeeSchedule.astro
+++ b/src/components/FeeSchedule.astro
@@ -1,0 +1,437 @@
+---
+// /fees — locked layout B "The Posted Card" (wayfinder #36), copy per
+// docs/copy-map.md §3.4. Ink ground; the rate card is a Cab Yellow card object
+// (app-icon scheme — no wordmark on yellow), the two fee families are paper
+// panels beside it, and the example runs as Cab-Yellow-as-text on the dark
+// ground (legal on dark only).
+//
+// Every amount comes from the runtime fetch — nothing here is hard-coded
+// (copy-map §0.4) — so the card, the charge panels and the example are built by
+// the client script below. The headings, leads, surge section and CTA are static:
+// they are claims about how YeRide charges, true in every fetch state.
+import appIcon from "@yeapptech/yeride-brand/assets/logo/yeride-app-icon.svg";
+import { feesCopy, type Lang } from "../i18n/feesCopy";
+
+export interface Props {
+  lang: Lang;
+}
+const { lang } = Astro.props;
+const t = feesCopy[lang];
+const esPrefix = lang === "es" ? "/es" : "";
+---
+
+<main class="bg-ink">
+  <div class="mx-auto w-full max-w-6xl px-5 pb-16 pt-8 sm:px-6 sm:pt-12">
+    {/* "Fetched live" is a claim about this render — only the loaded state earns it. */}
+    <p
+      data-fee-stamp
+      hidden
+      class="text-xs font-bold uppercase tracking-caps text-cab-yellow"
+    >
+    </p>
+
+    <h1
+      class="mt-3 max-w-2xl font-extrabold tracking-headline text-[2.1rem] leading-[1.05] text-paper sm:text-[2.75rem] md:text-[3.25rem]"
+    >
+      {t.h1}
+    </h1>
+    <p class="mt-4 max-w-xl text-[16px] text-paper/70 sm:text-[18px]">{t.lead}</p>
+
+    <div data-fee-state="loading" class="mt-12">
+      <p class="text-[15px] text-paper/60">{t.loading}</p>
+      <div
+        class="mt-6 h-64 max-w-md animate-pulse rounded-2xl bg-paper/10"
+        aria-hidden="true"
+      >
+      </div>
+    </div>
+
+    <div
+      data-fee-state="error"
+      hidden
+      class="mt-12 max-w-xl rounded-xl border border-paper/25 bg-paper/5 px-5 py-4"
+    >
+      <p class="text-[15px] text-paper" role="alert">
+        {t.errorPre}<a
+          href={`${esPrefix}/contact`}
+          class="font-bold text-cab-yellow underline underline-offset-2"
+          >{t.errorLink}</a
+        >{t.errorPost}
+      </p>
+    </div>
+
+    <div data-fee-state="loaded" hidden>
+      {/* every figure on the page is per-area — changing this re-fetches */}
+      <label class="mt-8 flex items-center gap-3">
+        <span class="text-xs font-bold uppercase tracking-caps text-paper/50"
+          >{t.areaLabel}</span
+        >
+        <select
+          data-fee-area
+          class="rounded-full border border-paper/30 bg-ink px-4 py-2 text-[14px] font-semibold text-paper hover:border-paper/60"
+        >
+        </select>
+      </label>
+
+      <div class="mt-8 grid gap-10 lg:grid-cols-[minmax(0,30rem)_1fr] lg:gap-16">
+        <div>
+          <div class="rounded-2xl bg-cab-yellow px-6 py-7 shadow-2xl sm:px-7">
+            <div class="flex items-center justify-between gap-4">
+              <h2 class="font-extrabold tracking-headline text-[1.3rem] text-ink">
+                {t.rateCardH2}
+              </h2>
+              <img src={appIcon.src} alt="" class="-mr-1 h-9 w-auto" />
+            </div>
+            <div data-fee-card></div>
+          </div>
+          <p class="mt-3 max-w-sm text-[13px] text-paper/50">{t.unitNote}</p>
+        </div>
+
+        <div
+          data-fee-families
+          class="grid items-start gap-6 md:grid-cols-2"
+        >
+        </div>
+      </div>
+
+      <section class="mt-14 border-t border-paper/15 pt-10">
+        <h2 class="font-extrabold tracking-headline text-[1.35rem] text-paper">
+          {t.exampleH2}
+        </h2>
+        <div data-fee-example></div>
+      </section>
+    </div>
+
+    {/* surge is static copy — it holds in every fetch state */}
+    <section class="mt-14 max-w-3xl border-t border-paper/15 pt-10">
+      <h2 class="font-extrabold tracking-headline text-[1.35rem] text-paper">
+        {t.surgeH2}
+      </h2>
+      <p class="mt-3 text-[15px] leading-relaxed text-paper/70 sm:text-[16px]">
+        {t.surgeBody}
+      </p>
+    </section>
+
+    <a
+      href={`${esPrefix}/fare-estimate`}
+      class="mt-12 flex w-full items-center justify-center gap-2 rounded-full bg-cab-yellow px-8 py-4 text-[16px] font-bold text-ink hover:bg-paper sm:inline-flex sm:w-auto"
+    >
+      {t.estimateLink}
+      <span aria-hidden="true">→</span>
+    </a>
+  </div>
+</main>
+
+<script>
+  import {
+    getFeeSchedule,
+    perMile,
+    metersToMiles,
+    usd,
+    type AppCharge,
+    type ChargeRule,
+    type FeeSchedule,
+    type RideService,
+  } from "../lib/feeSchedule";
+  import { feeLabels, serviceAreaName, type ChargeLabel } from "../i18n/feeLabels";
+  import { feesCopy, type Lang } from "../i18n/feesCopy";
+
+  const lang = (document.documentElement.lang === "es" ? "es" : "en") as Lang;
+  const t = feesCopy[lang];
+
+  function el<T extends Element>(sel: string): T | null {
+    return document.querySelector<T>(sel);
+  }
+
+  const stamp = el<HTMLParagraphElement>("[data-fee-stamp]");
+  const states = {
+    loading: el<HTMLElement>('[data-fee-state="loading"]'),
+    error: el<HTMLElement>('[data-fee-state="error"]'),
+    loaded: el<HTMLElement>('[data-fee-state="loaded"]'),
+  };
+  const areaSelect = el<HTMLSelectElement>("[data-fee-area]");
+  const cardSlot = el<HTMLElement>("[data-fee-card]");
+  const familiesSlot = el<HTMLElement>("[data-fee-families]");
+  const exampleSlot = el<HTMLElement>("[data-fee-example]");
+
+  function show(state: keyof typeof states) {
+    for (const [name, node] of Object.entries(states)) {
+      if (node) node.hidden = name !== state;
+    }
+    // the stamp is part of the loaded state and nothing else
+    if (stamp) stamp.hidden = state !== "loaded";
+  }
+
+  const esc = (s: string) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+  /** A missing rate is a gap in the source document — never $0.00. */
+  const GAP = "—";
+  const rate = (n: number | null | undefined) => usd(n) ?? GAP;
+
+  /** Phrase the endpoint's machine-readable rule; never invent one. */
+  function ruleText(rule: ChargeRule | null | undefined): string {
+    if (!rule) return GAP;
+    switch (rule.kind) {
+      case "flat":
+        return `${usd(rule.amount)} ${t.perTrip}`;
+      case "per_minute":
+        return `${usd(rule.amount)} ${t.perMinute}`;
+      case "per_km":
+        return `${usd(perMile(rule.amount))} ${t.perMile}`;
+      case "percent_of_fare": {
+        const base = `${rule.percent}% ${t.percentOfFare}`;
+        return rule.plus ? `${base} + ${usd(rule.plus)}` : base;
+      }
+      default:
+        return GAP;
+    }
+  }
+
+  function fetchedStamp(iso: string): string {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return t.fetchedStamp;
+    const time = new Intl.DateTimeFormat(t.locale, {
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(d);
+    const date = new Intl.DateTimeFormat(t.locale, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(d);
+    return `${t.fetchedStamp} · ${time} · ${date}`;
+  }
+
+  // ---- the posted card ----------------------------------------------------
+
+  const rateColumns = (s: RideService) =>
+    [
+      [t.rateRows.base, rate(s.baseFare)],
+      [t.rateRows.distance, rate(typeof s.costPerKm === "number" ? perMile(s.costPerKm) : null)],
+      [t.rateRows.time, rate(s.costPerMinute)],
+      [t.rateRows.minimum, rate(s.minimumFare)],
+      [t.rateRows.cancellation, rate(s.cancelationFee)],
+    ] as const;
+
+  function renderCard(services: RideService[]): string {
+    // Six columns don't fit a 390px card, so below sm each service transposes to
+    // its own mini-ledger; the services-as-rows table holds from sm up (#36).
+    const miniLedgers = services
+      .map(
+        (s) => `<div class="mt-4 border-t-2 border-ink/25 pt-2 first:mt-2">
+          <p class="text-[12px] font-bold uppercase tracking-caps text-ink/60">${esc(s.name)}</p>
+          <ul class="text-[14px] tabular-nums text-ink">${rateColumns(s)
+            .map(
+              ([label, amount]) =>
+                `<li class="flex items-baseline justify-between gap-3 border-b border-ink/15 py-2 last:border-b-0">
+                  <span class="font-semibold">${esc(label)}</span>
+                  <span class="font-extrabold">${esc(amount)}</span>
+                </li>`,
+            )
+            .join("")}</ul>
+        </div>`,
+      )
+      .join("");
+
+    const head = rateColumns(services[0])
+      .map(([label]) => `<th class="py-2 pl-2 text-right font-bold">${esc(label)}</th>`)
+      .join("");
+
+    const rows = services
+      .map(
+        (s) => `<tr class="border-b border-ink/15 last:border-b-0">
+          <td class="py-3 pr-2 font-semibold">${esc(s.name)}</td>
+          ${rateColumns(s)
+            .map(
+              ([, amount]) =>
+                `<td class="py-3 pl-2 text-right font-extrabold">${esc(amount)}</td>`,
+            )
+            .join("")}
+        </tr>`,
+      )
+      .join("");
+
+    return `<div class="mt-1 sm:hidden">${miniLedgers}</div>
+      <table class="mt-4 hidden w-full text-[14px] tabular-nums sm:table">
+        <thead>
+          <tr class="border-b border-ink/25 text-[11px] uppercase tracking-caps text-ink/60">
+            <th class="py-2 pr-2 text-left font-bold"></th>${head}
+          </tr>
+        </thead>
+        <tbody class="text-ink">${rows}</tbody>
+      </table>`;
+  }
+
+  // ---- the fee families ---------------------------------------------------
+
+  const chargeNotes: Record<string, string> = {
+    "trip-insurance-driver": t.insuranceNote,
+    "card-processing": t.cardNote,
+  };
+
+  const label = (c: AppCharge): ChargeLabel | undefined => feeLabels[c.id];
+  // An unmapped id keeps the backend description verbatim in both languages
+  // rather than leaking an English guess (copy-map §2.3).
+  const chargeName = (c: AppCharge) => label(c)?.[lang] ?? c.description;
+
+  function renderFamilies(charges: AppCharge[]): string {
+    const panels: { h2: string; lead: string; charges: AppCharge[] }[] = [
+      {
+        h2: t.family1H2,
+        lead: t.family1Lead,
+        charges: charges.filter((c) => label(c)?.family === "tech"),
+      },
+      {
+        h2: t.family2H2,
+        lead: t.family2Lead,
+        charges: charges.filter((c) => label(c)?.family === "passthrough"),
+      },
+      {
+        // Filing an unclassified charge into either family would be a claim
+        // about YeRide's economics that nothing supports — it gets its own panel.
+        h2: t.otherFamilyH2,
+        lead: t.otherFamilyLead,
+        charges: charges.filter((c) => !label(c)),
+      },
+    ];
+
+    return panels
+      .filter((p) => p.charges.length > 0)
+      .map(
+        (p) => `<section class="rounded-2xl bg-paper px-6 py-6">
+          <h2 class="font-extrabold tracking-headline text-[1.15rem] leading-snug text-ink">${esc(p.h2)}</h2>
+          <p class="mt-2 text-[14px] text-ink/65">${esc(p.lead)}</p>
+          <ul class="mt-3 text-[14px]">${p.charges
+            .map(
+              (c) => `<li class="border-b border-ink/10 py-2.5 last:border-b-0">
+                <div class="flex items-baseline justify-between gap-3">
+                  <span class="text-ink">${esc(chargeName(c))}</span>
+                  <span class="text-right font-bold tabular-nums text-ink">${esc(ruleText(c.rule))}</span>
+                </div>
+                ${
+                  chargeNotes[c.id]
+                    ? `<p class="mt-1.5 text-[12.5px] text-ink/50">${esc(chargeNotes[c.id])}</p>`
+                    : ""
+                }
+              </li>`,
+            )
+            .join("")}</ul>
+        </section>`,
+      )
+      .join("");
+  }
+
+  // ---- the example ledger -------------------------------------------------
+
+  const ledgerRow = (name: string, amount: string) =>
+    `<li class="flex items-baseline justify-between gap-4 border-b border-paper/15 py-2.5 text-paper">
+      <span>${esc(name)}</span><span class="font-bold">${esc(amount)}</span>
+    </li>`;
+
+  // Cab Yellow as text — legal on dark grounds only (#33).
+  const ledgerTotal = (name: string, amount: string) =>
+    `<li class="flex items-baseline justify-between gap-4 py-3">
+      <span class="font-bold text-cab-yellow">${esc(name)}</span>
+      <span class="text-[1.5rem] font-extrabold leading-none text-cab-yellow">${esc(amount)}</span>
+    </li>`;
+
+  function renderExample(schedule: FeeSchedule): string {
+    const ex = schedule.example;
+    // The ledger's claim is that the money reconciles across both columns. An
+    // unclassified charge would land on neither side, so the ledger is withheld
+    // rather than shown short.
+    const classified = schedule.appCharges.every((c) => label(c));
+    if (!ex || !classified) {
+      return `<p class="mt-3 max-w-xl text-[14px] text-paper/60">${esc(t.exampleUnavailable)}</p>`;
+    }
+
+    const amounts = new Map(ex.appCharges.map((c) => [c.id, c.amount]));
+    const of = (id: string) => amounts.get(id) ?? 0;
+    const ids = (test: (l: ChargeLabel) => boolean) =>
+      schedule.appCharges.filter((c) => {
+        const l = label(c);
+        return l ? test(l) : false;
+      });
+
+    const techTotal = ids((l) => l.family === "tech").reduce((n, c) => n + of(c.id), 0);
+    const riderPass = ids((l) => l.family === "passthrough" && l.payer === "rider");
+    const driverPass = ids((l) => l.family === "passthrough" && l.payer === "driver");
+
+    const riderTotal =
+      ex.fare + techTotal + riderPass.reduce((n, c) => n + of(c.id), 0);
+    const driverCard = ex.fare - driverPass.reduce((n, c) => n + of(c.id), 0);
+    const driverCash =
+      ex.fare -
+      driverPass.filter((c) => !label(c)?.cardOnly).reduce((n, c) => n + of(c.id), 0);
+
+    const service = schedule.rideServices.find((s) => s.id === ex.serviceId);
+    const miles = Math.round(metersToMiles(ex.distanceMeters) * 10) / 10;
+    const trip = [
+      `${miles} ${t.miles}`,
+      `${ex.durationMinutes} ${t.minutes}`,
+      service?.name,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
+    return `<p class="mt-1.5 text-[13px] text-paper/50">${esc(trip)} — ${esc(t.exampleNote)}</p>
+      <div class="mt-8 grid max-w-3xl gap-10 tabular-nums md:grid-cols-2 md:gap-14">
+        <div>
+          <p class="text-xs font-bold uppercase tracking-caps text-cab-yellow">${esc(t.riderColH)}</p>
+          <ul class="mt-4 text-[15px]">
+            ${ledgerRow(t.exampleFare, usd(ex.fare) ?? GAP)}
+            ${ledgerRow(t.exampleFees, usd(techTotal) ?? GAP)}
+            ${riderPass.map((c) => ledgerRow(chargeName(c), usd(of(c.id)) ?? GAP)).join("")}
+            ${ledgerTotal(t.colTotal, usd(riderTotal) ?? GAP)}
+          </ul>
+        </div>
+        <div>
+          <p class="text-xs font-bold uppercase tracking-caps text-cab-yellow">${esc(t.driverColH)}</p>
+          <ul class="mt-4 text-[15px]">
+            ${ledgerRow(t.exampleFare, usd(ex.fare) ?? GAP)}
+            ${driverPass.map((c) => ledgerRow(chargeName(c), `−${usd(of(c.id)) ?? GAP}`)).join("")}
+            ${ledgerTotal(t.driverTotalCard, usd(driverCard) ?? GAP)}
+          </ul>
+          <p class="text-[12.5px] text-paper/50">${esc(t.cashNotePre)}<span class="font-bold text-paper/75">${esc(
+            usd(driverCash) ?? GAP,
+          )}</span>${esc(t.cashNotePost)}</p>
+        </div>
+      </div>`;
+  }
+
+  // ---- fetch --------------------------------------------------------------
+
+  function render(schedule: FeeSchedule) {
+    if (!schedule.rideServices?.length) throw new Error("schedule has no ride services");
+
+    if (stamp) stamp.textContent = fetchedStamp(schedule.fetchedAt);
+    if (areaSelect) {
+      areaSelect.innerHTML = (schedule.areas ?? [schedule.area])
+        .map(
+          (a) =>
+            `<option value="${esc(a.id)}"${a.id === schedule.area.id ? " selected" : ""}>${esc(
+              serviceAreaName(a.id, a.identifier),
+            )}</option>`,
+        )
+        .join("");
+    }
+    if (cardSlot) cardSlot.innerHTML = renderCard(schedule.rideServices);
+    if (familiesSlot) familiesSlot.innerHTML = renderFamilies(schedule.appCharges ?? []);
+    if (exampleSlot) exampleSlot.innerHTML = renderExample(schedule);
+    show("loaded");
+  }
+
+  async function load(areaId?: string) {
+    show("loading");
+    try {
+      render(await getFeeSchedule(areaId));
+    } catch (err) {
+      console.error("[fees] could not load the schedule", err);
+      show("error");
+    }
+  }
+
+  areaSelect?.addEventListener("change", () => load(areaSelect.value));
+  load();
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,12 +3,14 @@
 // approved Variant D direction (wayfinder #33).
 import lockup from "@yeapptech/yeride-brand/assets/logo/yeride-lockup.svg";
 import appIcon from "@yeapptech/yeride-brand/assets/logo/yeride-app-icon.svg";
+import markReversed from "@yeapptech/yeride-brand/assets/logo/yeride-mark-reversed.svg";
 
 export interface Props {
   lang?: "en" | "es";
   /** The ground the header sits on. The lockup embeds the primary mark, which
-   *  logo.md forbids on Cab Yellow — yellow grounds use the app-icon scheme. */
-  ground?: "paper" | "yellow";
+   *  logo.md forbids on Cab Yellow — yellow grounds use the app-icon scheme.
+   *  Ink grounds (the /fees page, wayfinder #36) take the reversed mark. */
+  ground?: "paper" | "yellow" | "ink";
   /** Language-toggle target — the same page in the other language. */
   toggleHref: string;
 }
@@ -34,8 +36,19 @@ const t = {
 }[lang];
 
 const esPrefix = lang === "es" ? "/es" : "";
-const mark = ground === "yellow" ? appIcon : lockup;
-const bg = ground === "yellow" ? "bg-cab-yellow" : "bg-paper";
+const mark =
+  ground === "yellow" ? appIcon : ground === "ink" ? markReversed : lockup;
+const bg =
+  ground === "yellow" ? "bg-cab-yellow" : ground === "ink" ? "bg-ink" : "bg-paper";
+// Ink grounds invert the link and toggle tones; paper and yellow both take ink text.
+const dark = ground === "ink";
+const linkTone = dark
+  ? "text-paper/70"
+  : "text-ink/75";
+const linkHover = dark ? "hover:text-paper" : "hover:text-ink";
+const toggleTone = dark
+  ? "border-paper/30 text-paper/70 hover:border-paper/60"
+  : "border-ink/30 text-ink/70 hover:border-ink/60";
 ---
 
 <header class={bg}>
@@ -48,25 +61,31 @@ const bg = ground === "yellow" ? "bg-cab-yellow" : "bg-paper";
     {/* Below sm the links drop; the mark and the toggle always survive —
         ES parity is not a progressive enhancement (copy-map §1.1). */}
     <nav
-      class="ml-auto flex items-center gap-5 text-[15px] font-semibold text-ink/75 sm:gap-7"
+      class:list={[
+        "ml-auto flex items-center gap-5 text-[15px] font-semibold sm:gap-7",
+        linkTone,
+      ]}
     >
-      <a href={`${esPrefix}/drivers`} class="hidden hover:text-ink sm:inline"
+      <a href={`${esPrefix}/drivers`} class:list={["hidden sm:inline", linkHover]}
         >{t.drivers}</a
       >
-      <a href={`${esPrefix}/riders`} class="hidden hover:text-ink sm:inline"
+      <a href={`${esPrefix}/riders`} class:list={["hidden sm:inline", linkHover]}
         >{t.riders}</a
       >
-      <a href={`${esPrefix}/fees`} class="hidden hover:text-ink sm:inline"
+      <a href={`${esPrefix}/fees`} class:list={["hidden sm:inline", linkHover]}
         >{t.fees}</a
       >
       <a
         href={`${esPrefix}/fare-estimate`}
-        class="hidden hover:text-ink md:inline">{t.estimate}</a
+        class:list={["hidden md:inline", linkHover]}>{t.estimate}</a
       >
       <a
         href={toggleHref}
         aria-label={t.toggleAria}
-        class="rounded-full border border-ink/30 px-3 py-2 text-xs font-bold uppercase tracking-caps text-ink/70 hover:border-ink/60 sm:py-1"
+        class:list={[
+          "rounded-full border px-3 py-2 text-xs font-bold uppercase tracking-caps sm:py-1",
+          toggleTone,
+        ]}
         >{t.toggle}</a
       >
     </nav>

--- a/src/i18n/feeLabels.ts
+++ b/src/i18n/feeLabels.ts
@@ -1,0 +1,92 @@
+// ES labels for backend charge ids, keyed by id (copy-map §2.3), plus the
+// editorial classification /fees needs. Charge lines arrive from the database as
+// a single English `description`; Spanish is authored here, not translated by the
+// backend.
+//
+// Beyond the label, each entry says which of the two `docs/positioning.md`
+// families the charge belongs to and whose side of the example ledger it lands
+// on — neither is a database field, and neither is something the endpoint can
+// infer. Misfiling a charge would make a false claim about YeRide's economics,
+// so an id this map doesn't cover is never guessed into a family (see /fees).
+//
+// UNVERIFIED (copy-map §6.8): the ids below are the names positioning.md uses
+// plus the rider/driver insurance split the #36 example ledger needs. They must
+// be read off production and pruned; the build check (#41) fails on any id the
+// endpoint returns that this map doesn't cover.
+
+export type ChargeFamily = "tech" | "passthrough";
+
+export interface ChargeLabel {
+  en: string;
+  es: string;
+  family: ChargeFamily;
+  /** Whose money the charge comes out of. */
+  payer: "rider" | "driver";
+  /** Charges that exist only on card fares — dropped from the cash footnote. */
+  cardOnly?: true;
+}
+
+export const feeLabels: Record<string, ChargeLabel> = {
+  "booking-fee": {
+    en: "Booking fee",
+    es: "Cargo por reserva",
+    family: "tech",
+    payer: "rider",
+  },
+  "dispatch-fee": {
+    en: "Dispatch fee",
+    es: "Cargo por despacho",
+    family: "tech",
+    payer: "rider",
+  },
+  "platform-fee": {
+    en: "Platform fee",
+    es: "Cargo de plataforma",
+    family: "tech",
+    payer: "rider",
+  },
+  "platform-minute-fee": {
+    en: "Per-minute platform fee",
+    es: "Cargo de plataforma por minuto",
+    family: "tech",
+    payer: "rider",
+  },
+  "trip-insurance-rider": {
+    en: "Trip insurance — rider share",
+    es: "Seguro del viaje — parte de quien viaja",
+    family: "passthrough",
+    payer: "rider",
+  },
+  "trip-insurance-driver": {
+    en: "Trip insurance — driver share",
+    es: "Seguro del viaje — parte de quien maneja",
+    family: "passthrough",
+    payer: "driver",
+  },
+  "card-processing": {
+    en: "Card processing",
+    es: "Procesamiento de tarjeta",
+    family: "passthrough",
+    payer: "driver",
+    cardOnly: true,
+  },
+};
+
+// Service-area documents carry an `identifier` slug and no display-name field
+// (yeride-admin-api docs/DATA-MODELS.md §serviceAreas), so the picker's labels
+// live here until the brand/admin side adds one. An area missing from this map
+// falls back to its humanised identifier.
+export const serviceAreaNames: Record<string, string> = {
+  "us-fl-south-florida": "South Florida",
+};
+
+export function serviceAreaName(id: string, identifier: string): string {
+  return (
+    serviceAreaNames[id] ??
+    identifier
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((w) => w[0].toUpperCase() + w.slice(1))
+      .join(" ")
+  );
+}

--- a/src/i18n/feesCopy.ts
+++ b/src/i18n/feesCopy.ts
@@ -1,0 +1,130 @@
+// /fees and /es/fees copy — VERBATIM from docs/copy-map.md §3.4 (wayfinder #34).
+// Do not reword, re-case, or re-punctuate.
+//
+// Three groups are additions this build needed and the copy map does not yet
+// carry; they are marked and flagged on #40:
+//   - `otherFamilyH2` / `otherFamilyLead` — where a charge id the site can't
+//     classify renders, since guessing it into either family would be a claim.
+//   - `exampleUnavailable` — the ledger claims the money reconciles, so it is
+//     withheld rather than shown incomplete when a charge is unclassified.
+//   - the unit and rule fragments used to phrase rates and rules in both
+//     languages from the endpoint's machine-readable forms.
+
+export type Lang = "en" | "es";
+
+export const feesCopy = {
+  en: {
+    h1: "The fee schedule",
+    lead: "Every fee YeRide charges, and every cost it passes through. Current amounts, fetched live.",
+    areaLabel: "Service area",
+    rateCardH2: "The rate card",
+    rateRows: {
+      base: "Base",
+      distance: "Per mile",
+      time: "Per minute",
+      minimum: "Minimum fare",
+      cancellation: "Cancellation fee",
+    },
+    unitNote: "Metered per kilometer; the per-mile figure is an exact conversion.",
+    family1H2: "YeRide tech fees",
+    family1Lead:
+      "Flat, per-trip, published. This is how YeRide earns — never a percentage of the fare.",
+    family2H2: "Passed through at cost — zero markup",
+    family2Lead: "Costs YeRide forwards without touching.",
+    insuranceNote:
+      "The coverage Florida requires during a ride. The rider's share and the driver's share are separate, published lines.",
+    cardNote:
+      "The card networks' standard rate, borne by the driver on card fares. Cash fares have none.",
+    // addition — unclassified charges
+    otherFamilyH2: "Other charges",
+    otherFamilyLead:
+      "Charges the platform publishes that this page does not yet describe.",
+    exampleH2: "Example at today’s rates",
+    exampleNote: "Computed from the schedule above, not a quote.",
+    riderColH: "What the rider pays",
+    driverColH: "What the driver keeps",
+    exampleFare: "Metered fare",
+    exampleFees: "YeRide tech fees",
+    colTotal: "Total",
+    driverTotalCard: "Total — card fare",
+    cashNotePre: "On a cash fare there’s no card processing — the driver keeps ",
+    cashNotePost: ".",
+    // addition — withheld ledger
+    exampleUnavailable:
+      "The example is unavailable until every published charge is described above.",
+    surgeH2: "No surge today",
+    surgeBody:
+      "There is no demand surcharge right now. If we ever add one, these rules hold: it will be published and capped, shown to you before you request a ride, and 100% of it goes to the driver. YeRide’s fees never change with demand.",
+    fetchedStamp: "Fetched live",
+    loading: "Loading current rates…",
+    errorPre: "We couldn’t load the current rates. Refresh, or ",
+    errorLink: "contact us",
+    errorPost: ".",
+    estimateLink: "Estimate a fare",
+    // addition — units and rule fragments
+    miles: "miles",
+    minutes: "minutes",
+    perTrip: "per trip",
+    perMinute: "per minute",
+    perMile: "per mile",
+    percentOfFare: "of the fare",
+    locale: "en-US",
+  },
+  es: {
+    h1: "El tarifario",
+    lead: "Cada cargo que cobra YeRide y cada costo que traslada. Montos actuales, en vivo.",
+    areaLabel: "Área de servicio",
+    rateCardH2: "El tarifario base",
+    rateRows: {
+      base: "Base",
+      distance: "Por milla",
+      time: "Por minuto",
+      minimum: "Tarifa mínima",
+      cancellation: "Cargo por cancelación",
+    },
+    unitNote: "Se mide por kilómetro; la cifra por milla es una conversión exacta.",
+    family1H2: "Cargos de tecnología de YeRide",
+    family1Lead:
+      "Fijos, por viaje y publicados. Así gana YeRide — nunca un porcentaje de la tarifa.",
+    family2H2: "Trasladados al costo — sin recargo",
+    family2Lead: "Costos que YeRide traslada sin tocar.",
+    insuranceNote:
+      "La cobertura que la Florida exige durante el viaje. La parte de quien viaja y la de quien maneja son líneas separadas y publicadas.",
+    cardNote:
+      "La tarifa estándar de las redes de tarjetas, que paga quien maneja en viajes con tarjeta. Los viajes en efectivo no la tienen.",
+    otherFamilyH2: "Otros cargos",
+    otherFamilyLead:
+      "Cargos que publica la plataforma y que esta página todavía no describe.",
+    exampleH2: "Ejemplo con las tarifas de hoy",
+    exampleNote: "Calculado con el tarifario de arriba; no es una cotización.",
+    riderColH: "Lo que paga quien viaja",
+    driverColH: "Lo que le queda a quien maneja",
+    exampleFare: "Tarifa del taxímetro",
+    exampleFees: "Cargos de tecnología de YeRide",
+    colTotal: "Total",
+    driverTotalCard: "Total — viaje con tarjeta",
+    cashNotePre:
+      "En un viaje en efectivo no hay procesamiento de tarjeta — a quien maneja le quedan ",
+    cashNotePost: ".",
+    exampleUnavailable:
+      "El ejemplo no está disponible hasta que cada cargo publicado esté descrito arriba.",
+    surgeH2: "Hoy no hay recargo por demanda",
+    surgeBody:
+      "Ahora mismo no hay recargo por demanda. Si algún día agregamos uno, estas reglas se cumplen: será publicado y con tope, se te muestra antes de pedir el viaje, y el 100% es para quien maneja. Los cargos de YeRide nunca cambian con la demanda.",
+    fetchedStamp: "En vivo",
+    loading: "Cargando las tarifas actuales…",
+    errorPre: "No pudimos cargar las tarifas actuales. Recarga la página o ",
+    errorLink: "escríbenos",
+    errorPost: ".",
+    estimateLink: "Estima una tarifa",
+    miles: "millas",
+    minutes: "minutos",
+    perTrip: "por viaje",
+    perMinute: "por minuto",
+    perMile: "por milla",
+    percentOfFare: "de la tarifa",
+    locale: "es-US",
+  },
+} as const;
+
+export type FeesCopy = (typeof feesCopy)[Lang];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,8 +13,9 @@ export interface Props {
   title: string;
   description?: string;
   lang?: "en" | "es";
-  /** Ground the header sits on — pages with a Cab Yellow hero pass "yellow". */
-  headerGround?: "paper" | "yellow";
+  /** Ground the header sits on — pages with a Cab Yellow hero pass "yellow",
+   *  the ink-ground /fees page passes "ink". */
+  headerGround?: "paper" | "yellow" | "ink";
   /** /404 and /redirect are single-file with a client-side language switch
    *  (copy-map §3.10–3.11) — they carry no hreflang alternates. */
   alternates?: boolean;

--- a/src/lib/feeSchedule.ts
+++ b/src/lib/feeSchedule.ts
@@ -1,0 +1,97 @@
+// The live fee schedule behind /fees (wayfinder #40).
+//
+// Amounts are never hard-coded (copy-map §0.4): the page fetches them at runtime
+// from `getFeeSchedule`, a public read-only endpoint in yeride-functions. The
+// response shape below is the pinned contract — it mirrors the Firestore
+// documents verbatim (`serviceAreas/{areaId}/rideServices` and `/appCharges`,
+// per research/fee-schedule-source.md) so a broken document stays visible here
+// instead of being masked as $0.00.
+//
+// Two fields are computed by the endpoint rather than returned raw, both for the
+// same reason — the site must not become a third evaluator of the JSONata charge
+// expressions (research/fee-schedule-source.md, drift risk b):
+//   - `rule`    — a machine-readable summary of the expression, which the site
+//                 renders as a plain-language rule in EN/ES. `null` when the
+//                 endpoint can't summarise the expression; the site then shows an
+//                 explicit gap rather than inventing one (copy-map §3.4).
+//   - `example` — one reference trip evaluated with the same code the meter uses.
+
+/** A row of the rate card. Rate fields are optional: a missing rate renders as an
+ *  explicit gap, never $0.00. Field names mirror the store, including the real
+ *  single-l `cancelationFee` spelling. */
+export interface RideService {
+  id: string;
+  name: string;
+  baseFare?: number | null;
+  costPerKm?: number | null;
+  costPerMinute?: number | null;
+  minimumFare?: number | null;
+  cancelationFee?: number | null;
+}
+
+/** A charge's expression reduced to a shape the site can phrase in both languages.
+ *  Anything the endpoint can't reduce comes back as `null`. */
+export type ChargeRule =
+  | { kind: "flat"; amount: number }
+  | { kind: "per_minute"; amount: number }
+  | { kind: "per_km"; amount: number }
+  | { kind: "percent_of_fare"; percent: number; plus?: number };
+
+export interface AppCharge {
+  id: string;
+  description: string;
+  rule?: ChargeRule | null;
+}
+
+export interface ServiceAreaRef {
+  id: string;
+  identifier: string;
+}
+
+/** One reference trip, evaluated server-side. `appCharges` carries the amount the
+ *  meter's own evaluator produced for each charge on that trip. */
+export interface FeeScheduleExample {
+  serviceId: string;
+  distanceMeters: number;
+  durationMinutes: number;
+  fare: number;
+  appCharges: { id: string; amount: number }[];
+}
+
+export interface FeeSchedule {
+  /** ISO 8601. Renders as the "Fetched live" stamp. */
+  fetchedAt: string;
+  /** Every area the picker offers. */
+  areas: ServiceAreaRef[];
+  /** The area this response describes. */
+  area: ServiceAreaRef;
+  rideServices: RideService[];
+  appCharges: AppCharge[];
+  example?: FeeScheduleExample | null;
+}
+
+const ENDPOINT = import.meta.env.PUBLIC_FEE_SCHEDULE_URL;
+
+/** Fetch the schedule. Omit `areaId` for the endpoint's default area. */
+export async function getFeeSchedule(areaId?: string): Promise<FeeSchedule> {
+  if (!ENDPOINT) throw new Error("PUBLIC_FEE_SCHEDULE_URL is not configured");
+  // The deployed value is the absolute function URL; the base keeps a relative
+  // one working for local stubs.
+  const url = new URL(ENDPOINT, window.location.origin);
+  if (areaId) url.searchParams.set("area", areaId);
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`getFeeSchedule responded ${res.status}`);
+  return (await res.json()) as FeeSchedule;
+}
+
+export const KM_PER_MILE = 1.609344;
+
+/** Rates are metered per kilometre; the card shows an exact conversion. */
+export const perMile = (costPerKm: number) => costPerKm * KM_PER_MILE;
+
+export const metersToMiles = (meters: number) => meters / 1000 / KM_PER_MILE;
+
+/** `null`/`undefined` is a gap in the source document, not a zero. */
+export function usd(n: number | null | undefined): string | null {
+  return typeof n === "number" && Number.isFinite(n) ? `$${n.toFixed(2)}` : null;
+}

--- a/src/pages/es/fees.astro
+++ b/src/pages/es/fees.astro
@@ -1,0 +1,14 @@
+---
+// /es/fees — the ES twin. Routes are mirrored with English slugs (copy-map §0.3).
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import FeeSchedule from "../../components/FeeSchedule.astro";
+---
+
+<BaseLayout
+  title="El tarifario | YeRide"
+  description="Cada cargo que cobra YeRide y cada costo que traslada al costo, con los montos actuales en vivo."
+  lang="es"
+  headerGround="ink"
+>
+  <FeeSchedule lang="es" />
+</BaseLayout>

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -1,0 +1,15 @@
+---
+// /fees — positioning obligation #3, web side (wayfinder #40).
+// Title and meta description per docs/copy-map.md §4.
+import BaseLayout from "../layouts/BaseLayout.astro";
+import FeeSchedule from "../components/FeeSchedule.astro";
+---
+
+<BaseLayout
+  title="The fee schedule | YeRide"
+  description="Every fee YeRide charges and every cost it passes through at cost, with current amounts fetched live."
+  lang="en"
+  headerGround="ink"
+>
+  <FeeSchedule lang="en" />
+</BaseLayout>


### PR DESCRIPTION
Resolves #40 (wayfinder map #30). Layout locked on #36, copy from #34 §3.4/§4, data source from #31.

## What ships

`/fees` and `/es/fees`, built on the merged brand foundation (#45). Layout **B "The Posted Card"** exactly as locked: ink ground, service-area picker, the rate card as a Cab Yellow card object with ride services as rows (transposing to per-service mini-ledgers below `sm`), the two `positioning.md` fee families as paper panels, and the example as a reconciling **rider-pays / driver-keeps** pair of ledgers in Cab-Yellow-as-text. Copy verbatim from copy-map §3.4.

| file | what |
|---|---|
| `src/lib/feeSchedule.ts` | the pinned `getFeeSchedule` contract + fetch, km→mi, currency |
| `src/i18n/feeLabels.ts` | ES charge labels keyed by id (copy-map §2.3) + family/payer classification, and service-area display names |
| `src/i18n/feesCopy.ts` | page copy, EN/ES |
| `src/components/FeeSchedule.astro` | the page, and the client script that renders every fetched amount |
| `src/pages/fees.astro`, `src/pages/es/fees.astro` | the two routes |
| `Header.astro`, `BaseLayout.astro` | new `ink` ground (reversed mark) for this page |

## The endpoint does not exist yet

`getFeeSchedule` is scoped by #31 but not built — filed as yeapptech/yeride-functions#21. **Until it lands, `/fees` renders its designed error state**, so #42 (ship) is blocked on it. The contract is pinned in `src/lib/feeSchedule.ts` and restated on that issue.

Two fields the endpoint computes rather than returning raw, so the site never becomes a third evaluator of the JSONata charge expressions (#31 drift risk b):
- `rule` — a machine-readable summary per charge, which the site phrases in EN/ES. `null` when it can't be summarised.
- `example` — one reference trip evaluated with the same code the meter uses.

## Honesty rules the page enforces

- A missing rate or unsummarisable rule renders as an explicit gap (`—`), **never `$0.00`** (#31).
- A charge id `feeLabels` doesn't cover is **never guessed into a family** — misfiling it would be a claim about YeRide's economics. It gets its own neutral "Other charges" panel and keeps the backend `description` verbatim in both languages.
- The example ledger claims the money reconciles across both columns, so it is **withheld entirely** rather than shown short when a charge is unclassified.
- "Fetched live" is stamped **only** in the loaded state.

## Verified

`npm run build` green (`astro check`: 0 errors), 9 pages incl. both routes. Rendered against a stub endpoint at 1280px and 390px, EN + ES, across **loaded / loading / error**, plus the unclassified-charge and missing-rate paths. Ledger reconciles: rider $20.66 = driver $13.76 + $3.75 tech + $0.90 + $1.35 insurance + $0.90 card.

Because no `read:packages` PAT was available locally, the build was verified against the local `yeride-brand` checkout via a temporary `package.json` override — **reverted before commit**, so CI resolves `@yeapptech/yeride-brand@1.0.1` from the registry as usual.

## Needs a human

- **`PUBLIC_FEE_SCHEDULE_URL`** added to the workflow's env step and CLAUDE.md — the **GitHub Secret still has to be created**, and it is empty in production until it is.
- **Charge ids are still unverified against production** (copy-map §6.8). `feeLabels` seeds the `positioning.md` names plus the rider/driver insurance split the ledger needs; they must be read off prod and pruned. #41's fee-label check is the guard.
- **Two copy additions** this build needed and copy-map §3.4 does not yet carry: `otherFamilyH2`/`otherFamilyLead` and `exampleUnavailable`. Marked in `feesCopy.ts`; they want the map owner's blessing.
- **Service-area display names** live in a site-side map — area docs carry only `identifier` (gap flagged on #36). Unmapped areas fall back to a humanised identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)