### PR TITLE
fix(fees): drop the pass-through claim — nothing is passed through

### DIFF
--- a/src/i18n/feesCopy.ts
+++ b/src/i18n/feesCopy.ts
@@ -15,7 +15,11 @@ export type Lang = "en" | "es";
 export const feesCopy = {
   en: {
     h1: "The fee schedule",
-    lead: "Every fee YeRide charges, and every cost it passes through. Current amounts, fetched live.",
+    // The pass-through clause was cut on 2026-08-01 (#47): insurance does not
+    // exist yet (#48) and card processing is not YeRide's to pass through —
+    // Stripe bills the driver's own connected account. Restore it when the
+    // pass-through family has members again.
+    lead: "Every fee YeRide charges. Current amounts, fetched live.",
     areaLabel: "Service area",
     rateCardH2: "The rate card",
     rateRows: {
@@ -72,7 +76,7 @@ export const feesCopy = {
   },
   es: {
     h1: "El tarifario",
-    lead: "Cada cargo que cobra YeRide y cada costo que traslada. Montos actuales, en vivo.",
+    lead: "Cada cargo que cobra YeRide. Montos actuales, en vivo.",
     areaLabel: "Área de servicio",
     rateCardH2: "El tarifario base",
     rateRows: {

--- a/src/pages/es/fees.astro
+++ b/src/pages/es/fees.astro
@@ -6,7 +6,7 @@ import FeeSchedule from "../../components/FeeSchedule.astro";
 
 <BaseLayout
   title="El tarifario | YeRide"
-  description="Cada cargo que cobra YeRide y cada costo que traslada al costo, con los montos actuales en vivo."
+  description="Cada cargo que cobra YeRide, con los montos actuales en vivo."
   lang="es"
   headerGround="ink"
 >

--- a/src/pages/fees.astro
+++ b/src/pages/fees.astro
@@ -7,7 +7,7 @@ import FeeSchedule from "../components/FeeSchedule.astro";
 
 <BaseLayout
   title="The fee schedule | YeRide"
-  description="Every fee YeRide charges and every cost it passes through at cost, with current amounts fetched live."
+  description="Every fee YeRide charges, with current amounts fetched live."
   lang="en"
   headerGround="ink"
 >


### PR DESCRIPTION
Follows #46. Findings on #47; insurance tracked as #48.

`/fees` went live claiming **"every cost it passes through"** — in the lead and in both meta descriptions. Neither member of that family exists:

- **Insurance does not exist yet.** Coverage has not been sourced (#48).
- **Card processing is not YeRide's to pass through.** Drivers are Stripe *standard* Connect accounts on *direct charges*, so Stripe bills the driver's own connected account directly. The platform never touches it — yeride-functions v2.9.1 removed `calculateStripeTransactionFee` for exactly this reason.

So the "passed through at cost — zero markup" family has **zero members**, and the page was making a claim it could not back.

| | before (live) | after |
|---|---|---|
| EN lead | Every fee YeRide charges, and every cost it passes through. Current amounts, fetched live. | Every fee YeRide charges. Current amounts, fetched live. |
| ES lead | Cada cargo que cobra YeRide y cada costo que traslada. Montos actuales, en vivo. | Cada cargo que cobra YeRide. Montos actuales, en vivo. |
| EN meta | …and every cost it passes through at cost, with current amounts fetched live. | Every fee YeRide charges, with current amounts fetched live. |
| ES meta | …y cada costo que traslada al costo, con los montos actuales en vivo. | Cada cargo que cobra YeRide, con los montos actuales en vivo. |

The clause is the only thing cut. The family-2 strings stay in `feesCopy.ts` — that panel renders empty and is omitted, so they are unreachable until #48 gives them members again.

`npm run build` green, `astro check` 0 errors, 9 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)