### PR TITLE
fix(fees): real charge ids, and a ledger split by who actually pays

### DIFF
--- a/src/components/FeeSchedule.astro
+++ b/src/components/FeeSchedule.astro
@@ -354,16 +354,21 @@ const esPrefix = lang === "es" ? "/es" : "";
         return l ? test(l) : false;
       });
 
-    const techTotal = ids((l) => l.family === "tech").reduce((n, c) => n + of(c.id), 0);
-    const riderPass = ids((l) => l.family === "passthrough" && l.payer === "rider");
-    const driverPass = ids((l) => l.family === "passthrough" && l.payer === "driver");
+    // Which side a charge lands on is decided by `payer` alone, never by family
+    // (#47). YeRide's charges come out of the driver's side in both payment
+    // flows, so a family-based split would have put them in the rider's column
+    // and published the wrong economics.
+    const sum = (list: AppCharge[]) => list.reduce((n, c) => n + of(c.id), 0);
+    const riderCharges = ids((l) => l.payer === "rider");
+    const driverCharges = ids((l) => l.payer === "driver");
+    // Charges that exist only on card fares — today there are none, since
+    // Stripe's fee is not a YeRide charge. The cash footnote and the
+    // "card fare" qualifier are meaningless without one, so both are gated.
+    const cardOnly = driverCharges.filter((c) => label(c)?.cardOnly);
 
-    const riderTotal =
-      ex.fare + techTotal + riderPass.reduce((n, c) => n + of(c.id), 0);
-    const driverCard = ex.fare - driverPass.reduce((n, c) => n + of(c.id), 0);
-    const driverCash =
-      ex.fare -
-      driverPass.filter((c) => !label(c)?.cardOnly).reduce((n, c) => n + of(c.id), 0);
+    const riderTotal = ex.fare + sum(riderCharges);
+    const driverCard = ex.fare - sum(driverCharges);
+    const driverCash = ex.fare - sum(driverCharges.filter((c) => !label(c)?.cardOnly));
 
     const service = schedule.rideServices.find((s) => s.id === ex.serviceId);
     const miles = Math.round(metersToMiles(ex.distanceMeters) * 10) / 10;
@@ -381,8 +386,7 @@ const esPrefix = lang === "es" ? "/es" : "";
           <p class="text-xs font-bold uppercase tracking-caps text-cab-yellow">${esc(t.riderColH)}</p>
           <ul class="mt-4 text-[15px]">
             ${ledgerRow(t.exampleFare, usd(ex.fare) ?? GAP)}
-            ${ledgerRow(t.exampleFees, usd(techTotal) ?? GAP)}
-            ${riderPass.map((c) => ledgerRow(chargeName(c), usd(of(c.id)) ?? GAP)).join("")}
+            ${riderCharges.map((c) => ledgerRow(chargeName(c), usd(of(c.id)) ?? GAP)).join("")}
             ${ledgerTotal(t.colTotal, usd(riderTotal) ?? GAP)}
           </ul>
         </div>
@@ -390,12 +394,16 @@ const esPrefix = lang === "es" ? "/es" : "";
           <p class="text-xs font-bold uppercase tracking-caps text-cab-yellow">${esc(t.driverColH)}</p>
           <ul class="mt-4 text-[15px]">
             ${ledgerRow(t.exampleFare, usd(ex.fare) ?? GAP)}
-            ${driverPass.map((c) => ledgerRow(chargeName(c), `−${usd(of(c.id)) ?? GAP}`)).join("")}
-            ${ledgerTotal(t.driverTotalCard, usd(driverCard) ?? GAP)}
+            ${driverCharges.map((c) => ledgerRow(chargeName(c), `−${usd(of(c.id)) ?? GAP}`)).join("")}
+            ${ledgerTotal(cardOnly.length ? t.driverTotalCard : t.colTotal, usd(driverCard) ?? GAP)}
           </ul>
-          <p class="text-[12.5px] text-paper/50">${esc(t.cashNotePre)}<span class="font-bold text-paper/75">${esc(
-            usd(driverCash) ?? GAP,
-          )}</span>${esc(t.cashNotePost)}</p>
+          ${
+            cardOnly.length
+              ? `<p class="text-[12.5px] text-paper/50">${esc(t.cashNotePre)}<span class="font-bold text-paper/75">${esc(
+                  usd(driverCash) ?? GAP,
+                )}</span>${esc(t.cashNotePost)}</p>`
+              : ""
+          }
         </div>
       </div>`;
   }

--- a/src/i18n/feeLabels.ts
+++ b/src/i18n/feeLabels.ts
@@ -9,10 +9,23 @@
 // infer. Misfiling a charge would make a false claim about YeRide's economics,
 // so an id this map doesn't cover is never guessed into a family (see /fees).
 //
-// UNVERIFIED (copy-map §6.8): the ids below are the names positioning.md uses
-// plus the rider/driver insurance split the #36 example ledger needs. They must
-// be read off production and pruned; the build check (#41) fails on any id the
-// endpoint returns that this map doesn't cover.
+// VERIFIED against production 2026-08-01 (#47) — these are the ids
+// `getFeeSchedule` actually returns, not the names positioning.md guessed. The
+// build check (#41) fails on any id the endpoint returns that this map misses.
+//
+// `payer` is "driver" for all four, and that is not a guess: YeRide's charges
+// come out of the driver's side in both payment flows (`yeride-functions
+// lib/payments.js` L268–310). On card the rider is charged `priceFare` — the
+// metered fare and nothing else — while `appChargesTotal` is taken from the
+// driver's connected account as the application fee. On cash the rider pays the
+// driver directly and YeRide then bills the driver's account for the same total.
+//
+// There are no pass-through charges. Insurance does not exist yet (#48), and
+// card processing is not YeRide's to pass through — drivers are Stripe standard
+// Connect accounts on direct charges, so Stripe bills their own account and the
+// platform never touches it. The seeded `trip-insurance-*` and `card-processing`
+// entries were removed for that reason; the `passthrough` family and `cardOnly`
+// stay defined for when #48 gives them members again.
 
 export type ChargeFamily = "tech" | "passthrough";
 
@@ -27,48 +40,33 @@ export interface ChargeLabel {
 }
 
 export const feeLabels: Record<string, ChargeLabel> = {
-  "booking-fee": {
-    en: "Booking fee",
+  bookingCharge: {
+    en: "Booking charge",
     es: "Cargo por reserva",
     family: "tech",
-    payer: "rider",
+    payer: "driver",
   },
-  "dispatch-fee": {
-    en: "Dispatch fee",
+  dispatchCharge: {
+    en: "Dispatch charge",
     es: "Cargo por despacho",
     family: "tech",
-    payer: "rider",
-  },
-  "platform-fee": {
-    en: "Platform fee",
-    es: "Cargo de plataforma",
-    family: "tech",
-    payer: "rider",
-  },
-  "platform-minute-fee": {
-    en: "Per-minute platform fee",
-    es: "Cargo de plataforma por minuto",
-    family: "tech",
-    payer: "rider",
-  },
-  "trip-insurance-rider": {
-    en: "Trip insurance — rider share",
-    es: "Seguro del viaje — parte de quien viaja",
-    family: "passthrough",
-    payer: "rider",
-  },
-  "trip-insurance-driver": {
-    en: "Trip insurance — driver share",
-    es: "Seguro del viaje — parte de quien maneja",
-    family: "passthrough",
     payer: "driver",
   },
-  "card-processing": {
-    en: "Card processing",
-    es: "Procesamiento de tarjeta",
-    family: "passthrough",
+  // The two "bandwidth" charges are the technology YeRide provides the driver to
+  // run a ride — directions, maps, tracking, payments — metered per minute over
+  // the two legs. Named for what they are; the admin console still calls them
+  // bandwidth (naming agreed with the map owner, 2026-08-02).
+  pickupBandwidthCharge: {
+    en: "Ride technology — to pickup",
+    es: "Tecnología del viaje — hasta la recogida",
+    family: "tech",
     payer: "driver",
-    cardOnly: true,
+  },
+  dropoffBandwidthCharge: {
+    en: "Ride technology — on trip",
+    es: "Tecnología del viaje — en ruta",
+    family: "tech",
+    payer: "driver",
   },
 };
 


### PR DESCRIPTION
Follows #46 and #49. Findings on #47; insurance tracked as #48.

## Two commits

**1. Drop the pass-through claim** *(already deployed via #49 — included here only because it shares the branch)*.

**2. Map the real production charge ids, and fix who the ledger charges.**

### The ids

Read off production. They are camelCase, and **none** of the copy map's guesses existed — so all four fell through to the neutral "Other charges" panel and leaked their English `description` onto `/es/fees`.

| production id | EN | ES |
|---|---|---|
| `bookingCharge` | Booking charge | Cargo por reserva |
| `dispatchCharge` | Dispatch charge | Cargo por despacho |
| `pickupBandwidthCharge` | Ride technology — to pickup | Tecnología del viaje — hasta la recogida |
| `dropoffBandwidthCharge` | Ride technology — on trip | Tecnología del viaje — en ruta |

"Bandwidth" is internal jargon. These are the technology YeRide provides the driver to run a ride — directions, maps, tracking, payments — metered per minute across the two legs. Named for what they are, per the map owner. **The admin console still calls them bandwidth**; the site owns display names.

### The ledger now splits by payer, never by family

YeRide's charges come out of the **driver's** side in both payment flows (`yeride-functions lib/payments.js` L268–310):

- **Card:** the rider is charged `priceFare` — the metered fare, nothing else. `appChargesTotal` is taken from the driver's connected account as the application fee.
- **Cash:** the rider pays the driver directly; YeRide then bills the driver's account for the same total.

The family-based split put them in the **rider's** column. That would have published the wrong economics — it never rendered only because the seeded ids happened not to match. Now the rider's column is the metered fare alone, and the driver's is the fare minus YeRide's published charges.

The cash footnote and the "card fare" qualifier are gated on a `cardOnly` charge existing. None does: Stripe's fee is not a YeRide charge, and insurance doesn't exist yet (#48). The seeded `trip-insurance-*` and `card-processing` entries are removed for the same reason; the `passthrough` family and `cardOnly` stay defined for when #48 restores them.

## Verified

`npm run build` green, `astro check` 0 errors. Rendered EN + ES against a stub mirroring production's exact response **plus** a populated `example`, since production returns `example: null` and the ledger can't otherwise be exercised. Economy, 5 mi / 15 min: rider pays $9.73, driver keeps $8.63 after $1.10 of charges — reconciles. `pickupBandwidthCharge` still renders its gap (`—`), since its expression isn't summarisable.

**Still open:** the endpoint returns `example: null`, so the ledger stays withheld in production until yeride-functions#21 adds the reference trip. And the driver's total will need a qualitative note about Stripe's fee, which has no publishable amount — that's the design decision still outstanding on #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)