### PR TITLE
fix(home): cut "Lower insurance cost." — YeRide has no insurance

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,8 +78,10 @@ import PreRegistrationForm from "../components/PreRegistrationForm.astro";
               Higher Earnings
             </h4>
             <p class="text-gray-700">
-              No commission or hidden fees. Lower insurance cost.
-              Your hard work, your money.
+              {/* "Lower insurance cost." was cut on 2026-08-02 (#47): YeRide has
+                  no insurance at all yet, let alone a cheaper one (#48). The rest
+                  of this body is pre-redesign and is replaced wholesale by #37. */}
+              No commission or hidden fees. Your hard work, your money.
             </p>
           </div>
           <div


### PR DESCRIPTION
Found while amending the copy map for the same claim (#47). Insurance tracked as #48.

The production home page has been telling drivers, under **"Higher Earnings"**:

> No commission or hidden fees. **Lower insurance cost.** Your hard work, your money.

**YeRide has no insurance coverage at all** — it still has to be sourced from a carrier (#48). A claim that it is *cheaper* has nothing behind it.

This is pre-redesign copy that #35 deliberately left in place when it migrated the page bodies to the new layout. #37 replaces this whole section, but the claim shouldn't sit in production until then.

Only that one sentence is cut. "No commission or hidden fees." is accurate and stays.

This was the **only** occurrence left in `src/` — I grepped every page body for `insurance` / `at cost` / `zero markup` / `seguro` / `al costo`.

`npm run build` green, `astro check` 0 errors; `dist/index.html` confirmed to contain no occurrence of "insurance".

🤖 Generated with [Claude Code](https://claude.com/claude-code)