### PR TITLE
feat(fees): disclose Stripe's card processing as Stripe's, not YeRide's

### DIFF
--- a/src/components/FeeSchedule.astro
+++ b/src/components/FeeSchedule.astro
@@ -102,6 +102,27 @@ const esPrefix = lang === "es" ? "/es" : "";
       </section>
     </div>
 
+    {/* Stripe's fee is not a YeRide charge and never comes from the fetch — it is
+        billed by Stripe straight to the driver's connected account. Disclosed
+        because the driver's side of the example is short without it, but kept
+        out of both fee families, and stated without a figure: YeRide does not
+        set that rate. Static, like surge — true in every fetch state. */}
+    <section class="mt-14 max-w-3xl border-t border-paper/15 pt-10">
+      <h2 class="font-extrabold tracking-headline text-[1.35rem] text-paper">
+        {t.stripeH2}
+      </h2>
+      <p class="mt-3 text-[15px] leading-relaxed text-paper/70 sm:text-[16px]">
+        {t.stripeBody}
+      </p>
+      <a
+        href="https://stripe.com/pricing"
+        class="mt-3 inline-flex items-center gap-1.5 text-[15px] font-bold text-cab-yellow underline underline-offset-2"
+      >
+        {t.stripeLink}
+        <span aria-hidden="true">→</span>
+      </a>
+    </section>
+
     {/* surge is static copy — it holds in every fetch state */}
     <section class="mt-14 max-w-3xl border-t border-paper/15 pt-10">
       <h2 class="font-extrabold tracking-headline text-[1.35rem] text-paper">
@@ -395,7 +416,12 @@ const esPrefix = lang === "es" ? "/es" : "";
           <ul class="mt-4 text-[15px]">
             ${ledgerRow(t.exampleFare, usd(ex.fare) ?? GAP)}
             ${driverCharges.map((c) => ledgerRow(chargeName(c), `−${usd(of(c.id)) ?? GAP}`)).join("")}
-            ${ledgerTotal(cardOnly.length ? t.driverTotalCard : t.colTotal, usd(driverCard) ?? GAP)}
+            ${ledgerTotal(
+              // With no card-only charge itemised, Stripe's fee is still coming
+              // off a card fare — so a bare "Total" would overstate take-home.
+              cardOnly.length ? t.driverTotalCard : t.driverTotalBeforeCard,
+              usd(driverCard) ?? GAP,
+            )}
           </ul>
           ${
             cardOnly.length

--- a/src/i18n/feesCopy.ts
+++ b/src/i18n/feesCopy.ts
@@ -51,11 +51,22 @@ export const feesCopy = {
     exampleFees: "YeRide tech fees",
     colTotal: "Total",
     driverTotalCard: "Total — card fare",
+    // Stripe's fee is real, driver-borne and never itemised here, so the driver's
+    // total would otherwise overstate take-home on a card fare (#47).
+    driverTotalBeforeCard: "Total — before card processing",
     cashNotePre: "On a cash fare there’s no card processing — the driver keeps ",
     cashNotePost: ".",
     // addition — withheld ledger
     exampleUnavailable:
       "The example is unavailable until every published charge is described above.",
+    // Named for what it is, and attributed (map owner, 2026-08-02). No figure:
+    // YeRide neither sets nor controls Stripe's rate, and with standard Connect
+    // accounts it is between the driver and Stripe — publishing one would assert
+    // a third party's pricing and break copy-map §0.4.
+    stripeH2: "Card processing is Stripe's, not YeRide's",
+    stripeBody:
+      "On card fares, Stripe charges its processing fee directly to the driver's own account. YeRide never touches it and doesn't set it. Cash fares have none.",
+    stripeLink: "See Stripe's pricing",
     surgeH2: "No surge today",
     surgeBody:
       "There is no demand surcharge right now. If we ever add one, these rules hold: it will be published and capped, shown to you before you request a ride, and 100% of it goes to the driver. YeRide’s fees never change with demand.",
@@ -107,11 +118,16 @@ export const feesCopy = {
     exampleFees: "Cargos de tecnología de YeRide",
     colTotal: "Total",
     driverTotalCard: "Total — viaje con tarjeta",
+    driverTotalBeforeCard: "Total — antes del procesamiento de tarjeta",
     cashNotePre:
       "En un viaje en efectivo no hay procesamiento de tarjeta — a quien maneja le quedan ",
     cashNotePost: ".",
     exampleUnavailable:
       "El ejemplo no está disponible hasta que cada cargo publicado esté descrito arriba.",
+    stripeH2: "El procesamiento de tarjeta es de Stripe, no de YeRide",
+    stripeBody:
+      "En los viajes con tarjeta, Stripe le cobra su cargo de procesamiento directamente a la cuenta de quien maneja. YeRide nunca lo toca ni lo fija. Los viajes en efectivo no lo tienen.",
+    stripeLink: "Mira los precios de Stripe",
     surgeH2: "Hoy no hay recargo por demanda",
     surgeBody:
       "Ahora mismo no hay recargo por demanda. Si algún día agregamos uno, estas reglas se cumplen: será publicado y con tope, se te muestra antes de pedir el viaje, y el 100% es para quien maneja. Los cargos de YeRide nunca cambian con la demanda.",


### PR DESCRIPTION
Closes the open design question on #47. Insurance tracked separately as #48.

Card processing is real and driver-borne, but it is **not a YeRide charge** and never arrives from the fetch — drivers are Stripe *standard* Connect accounts on *direct charges*, so Stripe bills their own connected account and the platform never touches it.

## What it says

> ### Card processing is Stripe's, not YeRide's
> On card fares, Stripe charges its processing fee directly to the driver's own account. YeRide never touches it and doesn't set it. Cash fares have none.
>
> [See Stripe's pricing →](https://stripe.com/pricing)

ES: *"El procesamiento de tarjeta es de Stripe, no de YeRide"*.

**Deliberately not in either fee family.** The copy map had it under "passed through at cost — zero markup", which implies YeRide handles it — it doesn't. It gets its own static section, like surge, present in every fetch state.

**No figure.** YeRide neither sets nor controls Stripe's rate, and with standard Connect accounts it's between the driver and Stripe — publishing one would assert a third party's pricing and break copy-map §0.4. The link carries that job instead.

## The consequence worth reviewing

With no card-only charge itemised, the driver's column would have shown a bare **"Total"** while Stripe still takes its cut of a card fare — **overstating take-home**. It now reads **"Total — before card processing"**, with the disclosure immediately below it. The "Total — card fare" label returns automatically if #48 ever itemises a real card-only charge.

## Verified

`npm run build` green, `astro check` 0 errors. Rendered EN + ES against a stub mirroring production's exact response plus a populated `example` — production still returns `example: null`, so the ledger and its new label can't otherwise be exercised. Economy, 5 mi / 15 min: rider pays $9.73, driver keeps $8.63 before card processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)