### PR TITLE
style(fees): typographic apostrophes in the Stripe section

### DIFF
--- a/src/i18n/feesCopy.ts
+++ b/src/i18n/feesCopy.ts
@@ -63,10 +63,10 @@ export const feesCopy = {
     // YeRide neither sets nor controls Stripe's rate, and with standard Connect
     // accounts it is between the driver and Stripe — publishing one would assert
     // a third party's pricing and break copy-map §0.4.
-    stripeH2: "Card processing is Stripe's, not YeRide's",
+    stripeH2: "Card processing is Stripe’s, not YeRide’s",
     stripeBody:
-      "On card fares, Stripe charges its processing fee directly to the driver's own account. YeRide never touches it and doesn't set it. Cash fares have none.",
-    stripeLink: "See Stripe's pricing",
+      "On card fares, Stripe charges its processing fee directly to the driver’s own account. YeRide never touches it and doesn’t set it. Cash fares have none.",
+    stripeLink: "See Stripe’s pricing",
     surgeH2: "No surge today",
     surgeBody:
       "There is no demand surcharge right now. If we ever add one, these rules hold: it will be published and capped, shown to you before you request a ride, and 100% of it goes to the driver. YeRide’s fees never change with demand.",


### PR DESCRIPTION
Follows #52, and keeps `docs/copy-map.md` § 3.4 (`2ec13a2`) matching the source byte-for-byte.

The rest of `/fees` uses curly apostrophes — "Example at today’s rates", "We couldn’t load the current rates", "YeRide’s fees never change with demand" — but the three Stripe strings I added in #52 shipped with straight ones, so both sat on the same page.

| | before | after |
|---|---|---|
| Stripe H2 | Card processing is Stripe**'**s, not YeRide**'**s | Card processing is Stripe**’**s, not YeRide**’**s |
| Stripe body | …the driver**'**s own account. YeRide never touches it and doesn**'**t set it. | …the driver**’**s own account. YeRide never touches it and doesn**’**t set it. |
| Stripe link | See Stripe**'**s pricing | See Stripe**’**s pricing |

Spanish is unaffected — it has no apostrophes.

Caught by diffing the shipped strings against the copy map while folding the card note in. `npm run build` green, and all ten § 3.4 Stripe/ledger strings re-verified as exact matches against the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)