### PR TITLE
fix(fees): close three holes found by independent review

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -161,6 +161,52 @@ The form uses Tailwind CSS classes for styling. Key classes:
 - `focus:ring-2 focus:ring-green-500` - Input focus states
 - `bg-green-600 hover:bg-green-700` - Submit button
 
+## Fee Components
+
+### FeeSchedule
+
+The whole body of `/fees` and `/es/fees` (wayfinder #40), on the locked "Posted Card"
+layout (#36).
+
+**Props**
+
+| Prop | Type | Required | Notes |
+|---|---|---|---|
+| `lang` | `"en" \| "es"` | yes | Selects the copy set from `src/i18n/feesCopy.ts` |
+
+**Usage**
+
+```astro
+<BaseLayout title="The fee schedule | YeRide" lang="en" headerGround="ink">
+  <FeeSchedule lang="en" />
+</BaseLayout>
+```
+
+**Why it carries a client script.** Every amount is fetched at runtime from
+`getFeeSchedule` — no fee figure may be hard-coded (copy map §0.4) — so the rate card,
+the charge panels and the example are built by the script from the response. Only the
+headings, leads, the Stripe section and surge are static, because those are claims that
+hold in every fetch state. The endpoint URL comes from `PUBLIC_FEE_SCHEDULE_URL`.
+
+**Three refusals it enforces.** These are the reason the component is shaped this way,
+and none of them should be relaxed without reading #47:
+
+1. A missing rate, or a rule the endpoint can't summarise, renders as an explicit gap
+   (`—`) — **never `$0.00`**, which would publish a wrong price as if it were real.
+2. A charge id `src/i18n/feeLabels.ts` doesn't cover is **never guessed into a fee
+   family**; it renders in a neutral panel, keeps the backend `description` verbatim in
+   both languages, and carries no family's notes.
+3. The example ledger claims the money reconciles across both columns, so it is
+   **withheld entirely** — never shown short — if any charge is unclassified *or* is
+   missing an amount in `example.appCharges`.
+
+The ledger splits by `payer`, never by family: YeRide's charges come out of the
+driver's side in both payment flows.
+
+**Related:** `src/lib/feeSchedule.ts` (endpoint contract, fetch, formatting),
+`src/i18n/feeLabels.ts` (charge labels + family/payer), `src/i18n/feesCopy.ts` (page
+copy, EN/ES).
+
 ## Page-Specific Components
 
 ### Homepage (index.astro)

--- a/src/components/FeeSchedule.astro
+++ b/src/components/FeeSchedule.astro
@@ -286,9 +286,15 @@ const esPrefix = lang === "es" ? "/es" : "";
 
   // ---- the fee families ---------------------------------------------------
 
-  const chargeNotes: Record<string, string> = {
+  // Notes belong to a family, not to a bare id — attaching them by id alone let
+  // an UNCLASSIFIED charge that happened to share the id print a family-2 claim
+  // from inside the neutral "Other charges" panel. They now live on the panel
+  // that owns them, so an unclassified charge can never carry one.
+  //
+  // There is deliberately no card-processing note: card processing is not a
+  // YeRide charge and is disclosed in its own section instead (copy-map §3.4).
+  const passthroughNotes: Record<string, string> = {
     "trip-insurance-driver": t.insuranceNote,
-    "card-processing": t.cardNote,
   };
 
   const label = (c: AppCharge): ChargeLabel | undefined => feeLabels[c.id];
@@ -297,23 +303,32 @@ const esPrefix = lang === "es" ? "/es" : "";
   const chargeName = (c: AppCharge) => label(c)?.[lang] ?? c.description;
 
   function renderFamilies(charges: AppCharge[]): string {
-    const panels: { h2: string; lead: string; charges: AppCharge[] }[] = [
+    const panels: {
+      h2: string;
+      lead: string;
+      charges: AppCharge[];
+      notes: Record<string, string>;
+    }[] = [
       {
         h2: t.family1H2,
         lead: t.family1Lead,
         charges: charges.filter((c) => label(c)?.family === "tech"),
+        notes: {},
       },
       {
         h2: t.family2H2,
         lead: t.family2Lead,
         charges: charges.filter((c) => label(c)?.family === "passthrough"),
+        notes: passthroughNotes,
       },
       {
         // Filing an unclassified charge into either family would be a claim
-        // about YeRide's economics that nothing supports — it gets its own panel.
+        // about YeRide's economics that nothing supports — it gets its own panel,
+        // and no family's notes.
         h2: t.otherFamilyH2,
         lead: t.otherFamilyLead,
         charges: charges.filter((c) => !label(c)),
+        notes: {},
       },
     ];
 
@@ -331,8 +346,8 @@ const esPrefix = lang === "es" ? "/es" : "";
                   <span class="text-right font-bold tabular-nums text-ink">${esc(ruleText(c.rule))}</span>
                 </div>
                 ${
-                  chargeNotes[c.id]
-                    ? `<p class="mt-1.5 text-[12.5px] text-ink/50">${esc(chargeNotes[c.id])}</p>`
+                  p.notes[c.id]
+                    ? `<p class="mt-1.5 text-[12.5px] text-ink/50">${esc(p.notes[c.id])}</p>`
                     : ""
                 }
               </li>`,
@@ -363,12 +378,20 @@ const esPrefix = lang === "es" ? "/es" : "";
     // unclassified charge would land on neither side, so the ledger is withheld
     // rather than shown short.
     const classified = schedule.appCharges.every((c) => label(c));
-    if (!ex || !classified) {
+    const amounts = new Map(ex?.appCharges.map((c) => [c.id, c.amount]) ?? []);
+    // A charge the endpoint priced in the schedule but omitted from the example
+    // would otherwise coalesce to 0 — printing "−$0.00" and overstating what the
+    // driver keeps. That is exactly the $0.00-masking-a-gap failure the rate-card
+    // research warned about, so it withholds the ledger like any other gap.
+    const priced = schedule.appCharges.every((c) => {
+      const a = amounts.get(c.id);
+      return typeof a === "number" && Number.isFinite(a);
+    });
+    if (!ex || !classified || !priced) {
       return `<p class="mt-3 max-w-xl text-[14px] text-paper/60">${esc(t.exampleUnavailable)}</p>`;
     }
 
-    const amounts = new Map(ex.appCharges.map((c) => [c.id, c.amount]));
-    const of = (id: string) => amounts.get(id) ?? 0;
+    const of = (id: string) => amounts.get(id) as number;
     const ids = (test: (l: ChargeLabel) => boolean) =>
       schedule.appCharges.filter((c) => {
         const l = label(c);


### PR DESCRIPTION
Findings from an independent two-axis review of `c68636a..main` (all /fees work). Three confirmed, fixed here; the rest triaged below.

## Fixed

**1. `−$0.00` overstating driver take-home — the serious one.**
`const of = (id) => amounts.get(id) ?? 0` coalesced a charge that the endpoint priced in `appCharges` but omitted from `example.appCharges`. The row printed **`−$0.00`** and the driver's total came out too high. This is exactly the $0.00-masking-a-gap failure #31 named as drift risk c, and the one the page publicly claims to prevent — the withhold guard checked *labels* only, never *amount coverage*. The ledger now withholds unless every charge has a finite amount.

**2. A family claim could escape into the neutral panel.**
Notes were keyed on raw charge id and applied in every panel, so an unclassified charge sharing an id (`trip-insurance-driver`, `card-processing`) would land in "Other charges" and *still* print the family-2 insurance/card note — defeating the entire point of that panel. Notes now belong to the panel that owns them.

**3. The card note was still wired.**
Copy map §3.4 replaced it with the standalone Stripe section (#52), but `cardNote` remained live in `chargeNotes`. Card processing is not a YeRide charge and must not render as a note on one. Removed.

Plus `docs/components.md` now documents `FeeSchedule` — required by `docs/contributing.md` ("Adding New Components → 4. Document usage") and skipped by #40.

## Verified

Reproduced hole 1 against a stub omitting `pickupBandwidthCharge` from the example: ledger correctly withheld, **no `$0.00` anywhere in the DOM**, rate card and families still render. Old code printed `−$0.00`. Complete stub still reconciles: rider $9.73 = driver $8.63 + $1.10. `npm run build` green.

## Triaged, not fixed

- **"Homepage doesn't link /fees"** — **incorrect finding.** `index.astro` uses `BaseLayout` → shared `Header`; production serves `href="/fees"`. The reviewer was misled by CLAUDE.md, which still describes the pre-#35 inline-header architecture. Real problem, wrong target: the docs are stale, already tracked on #30 as "Website repo docs refresh".
- **Dead copy strings** (`family2H2/Lead`, `insuranceNote`, `cashNote*`, `exampleFees`) — deliberately retained, marked SUSPENDED in copy map §3.4, and restored by #48.
- **`esc()` omits `'`** — safe today (every attribute is double-quoted) but fragile. Worth hardening separately.
- **Ledger arithmetic lives in the view** — fair; it belongs in `feeSchedule.ts` where it could be unit-tested. Repo has no test runner, so that is a bigger change than this PR.
- **Copy-map apostrophe drift** on three pre-existing strings — fixing on the doc branch, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)