### PR TITLE
fix(form): close the duplicate-row phone bug the first fix missed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,22 +53,31 @@ The site talks to two unrelated services; don't conflate them.
 
 `firebase-admin` is in `package.json` but unused in `src/`. Firebase Auth and Firestore are not used — only `firebase/functions`.
 
-### Page structure is inconsistent — check before editing shared UI
+### Page structure — one layout, thin pages
 
-There is no single layout. Each page declares its own `<html>`/`<head>`:
+Every page renders through the single `src/layouts/BaseLayout.astro` (wayfinder #35). **No
+page declares its own `<html>`/`<head>`**, and no page carries inline header or footer
+markup — `Header.astro` and `Footer.astro` have one caller each, `BaseLayout`. A navigation
+or footer change is therefore one edit, in one place.
 
-- `src/pages/404.astro` — the **only** page using `BaseLayout.astro`, which is also the only consumer of `navBar.astro`, `src/data/navData.ts`, and `src/styles/main.css` (Open Props from unpkg). `navData.ts` lists routes (`ride`, `drive`, `register`) that don't exist.
-- `src/pages/index.astro` — fully self-contained, with its own inline header and footer markup (does *not* use the `Header`/`Footer` components).
-- `about`, `contact`, `privacy-policy`, `fare-estimate` — self-contained `<html>` importing the `Header` and `Footer` components.
+Redesigned routes keep the page file thin — `BaseLayout` plus one component that holds the
+whole body (`HomePage`, `DriversPage`, `RidersPage`, `FeeSchedule`) — with the copy in
+`src/i18n/`. Follow that shape when adding a page. The pages still awaiting their redesign
+ticket (`about`, `contact`, `privacy-policy`, `fare-estimate`) sit on `BaseLayout` with
+their pre-redesign bodies inline.
 
-Consequence: a navigation or footer change usually needs edits in **both** `src/components/Header.astro` / `Footer.astro` **and** the inline copies in `index.astro`.
+`navBar.astro`, `src/data/navData.ts`, `src/styles/main.css` (Open Props from unpkg) and the
+`https://cdn.tailwindcss.com` script tags were all removed by #35. Tailwind comes from the
+`@astrojs/tailwind` integration and the brand preset alone — do not re-add a CDN tag.
 
-Also: `index`, `about`, `contact`, and `privacy-policy` load Tailwind from `https://cdn.tailwindcss.com` in `<head>`, *on top of* the `@astrojs/tailwind` build. `fare-estimate.astro` relies on the integration alone. When adding a page, match whichever surrounding page you're copying rather than assuming the integration is enough.
+Line endings are mixed and there is no `.gitattributes`: some older files are CRLF, most
+newer ones LF. Editing a CRLF file with a tool that rewrites it wholesale will convert it
+and bury your real change in a full-file diff.
 
 ### Other integrations
 
 - **Tally.so** — embedded contact form on `/contact` (form ID `mJa5J7`)
-- **Google Fonts** — Inter (400, 600, 700), linked per page
+- **Nunito** — the brand typeface, self-hosted via `@fontsource-variable/nunito` and imported once in `BaseLayout`; exposed as `font-brand`. The old per-page Google Fonts link to Inter is gone (#35)
 - `src/pages/redirect.astro` — bare HTML that bounces to the `yeride://register` deep link
 
 ## Coding Conventions

--- a/docs/components.md
+++ b/docs/components.md
@@ -13,20 +13,27 @@ The base layout template for all pages.
 **Props:**
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
-| `title` | `string` | No | Page title |
+| `title` | `string` | yes | `<title>`, per copy-map §4 |
+| `description` | `string` | no | Meta description, per copy-map §4 |
+| `lang` | `"en" \| "es"` | no (`"en"`) | Sets `<html lang>` and the chrome's language |
+| `headerGround` | `"paper" \| "yellow" \| "ink"` | no (`"paper"`) | The ground the header sits on, so it merges with the page's first section |
+| `alternates` | `boolean` | no (`true`) | EN/ES `hreflang` pair + `x-default`. Only `/404` and `/redirect` pass `false` — they are single-file by design (copy-map §3.10–§3.11) |
 
 **Usage:**
 
 ```astro
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import DriversPage from '../components/DriversPage.astro';
 ---
 
-<BaseLayout title="About Us">
-  <main>
-    <h1>About YeRide</h1>
-    <p>Your content here</p>
-  </main>
+<BaseLayout
+  title="Keep what you earn. | YeRide for drivers"
+  description="No commission — YeRide's fees are flat, published, and never a percentage of the fare. Run YeRide alongside Uber and Lyft."
+  lang="en"
+  headerGround="yellow"
+>
+  <DriversPage lang="en" />
 </BaseLayout>
 ```
 
@@ -34,70 +41,43 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 ### Header
 
-The main navigation header with mobile-responsive menu.
+Site header — copy per copy-map §1.1, styling per the approved "Hail" direction (#33).
+Rendered by `BaseLayout`; pages do not import it directly.
 
 **Location:** `src/components/Header.astro`
 
-**Features:**
-- Logo and brand name
-- Desktop navigation links
-- Mobile hamburger menu toggle
-- Smooth scroll to sections
-- Responsive design
+**Props:**
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `lang` | `"en" \| "es"` | no (`"en"`) | Selects the nav copy |
+| `ground` | `"paper" \| "yellow" \| "ink"` | no (`"paper"`) | Picks the legal mark for that ground and inverts link tones on ink. The lockup embeds the primary mark, which `logo.md` forbids on Cab Yellow, so yellow takes the app-icon scheme and ink the reversed mark |
+| `toggleHref` | `string` | **yes** | The same page in the other language |
 
-**Navigation Items:**
-- Home
-- About
-- Contact
-- Pre-Register (CTA button)
-
-**Usage:**
-
-```astro
----
-import Header from '../components/Header.astro';
----
-
-<Header />
-```
+**Navigation items** (order is fixed — audience pages, then the two proof pages, then the
+toggle): Drivers / Maneja, Riders / Viaja, Fees / Tarifas, Fare estimate / Estimar tarifa,
+then the ES⇄EN toggle. Below `sm` the links drop and **the mark and the toggle always
+survive** — ES parity is not a progressive enhancement. There is no hamburger menu.
 
 ### Footer
 
-The site footer with links and social media.
+Site footer — copy per copy-map §1.2. Rendered by `BaseLayout`.
 
 **Location:** `src/components/Footer.astro`
 
-**Features:**
-- Brand information
-- Quick links section
-- Social media links (Twitter, Instagram, Facebook)
-- Copyright notice
+**Props:**
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `lang` | `"en" \| "es"` | no (`"en"`) | Selects the link and line copy |
 
-**Usage:**
-
-```astro
----
-import Footer from '../components/Footer.astro';
----
-
-<Footer />
-```
+**Links:** About, Contact, Privacy Policy, Terms, plus the place, entity and copyright
+lines. **Social is X/Twitter only** — the Facebook and Instagram icons pointed at `#` and
+were removed for good. Do not re-add a social icon without a working URL.
 
 ### navBar
 
-A simple navigation bar component.
-
-**Location:** `src/components/navBar.astro`
-
-**Usage:**
-
-```astro
----
-import NavBar from '../components/navBar.astro';
----
-
-<NavBar />
-```
+**Removed.** `src/components/navBar.astro` and `src/data/navData.ts` were deleted by the
+brand foundation (wayfinder #35) — `navData` listed routes that never existed. `Header` is
+the only navigation component.
 
 ## Form Components
 
@@ -298,11 +278,18 @@ Example pattern:
 
 ### Color Scheme
 
-The primary color palette:
-- **Primary Green:** `#22c55e` (green-500)
-- **Dark Green:** `#16a34a` (green-600)
-- **Background:** `#f9fafb` (gray-50)
-- **Text:** `#111827` (gray-900)
+Four brand colours, and only these. They come from the `@yeapptech/yeride-brand` Tailwind
+preset — **never restate the hex values** (CONSUMING.md; wayfinder #35):
+
+| Token | Class | Notes |
+|---|---|---|
+| Cab Yellow | `cab-yellow` | Hero grounds. Legal as **text** only on dark grounds (#33) |
+| Ink | `ink` | Body text on paper; the dark band's ground |
+| Paper | `paper` | Page ground; text on ink |
+| Pullman Brown | `pullman-brown` | Hover state for ink buttons; validation errors |
+
+The green/grey palette documented here before was pre-brand and no longer exists in the
+build.
 
 ## Adding New Components
 
@@ -324,8 +311,8 @@ interface Props {
 const { variant = 'primary', href } = Astro.props;
 const baseClasses = 'px-6 py-3 rounded-lg font-semibold transition-colors';
 const variantClasses = {
-  primary: 'bg-green-600 text-white hover:bg-green-700',
-  secondary: 'bg-white text-green-600 border-2 border-green-600 hover:bg-green-50',
+  primary: 'bg-ink text-paper hover:bg-pullman-brown',
+  secondary: 'border-2 border-ink text-ink hover:bg-ink hover:text-paper',
 };
 ---
 

--- a/src/components/PreRegistrationForm.astro
+++ b/src/components/PreRegistrationForm.astro
@@ -132,7 +132,11 @@ const inputClass =
 
   {/* The success state. The availability block (§2.1) is the page's next
       element, so it stays on screen beneath this line rather than being
-      duplicated inside the form. */}
+      duplicated inside the form.
+
+      Unlike the alert above, this one IS revealed from `hidden` — announcement
+      here comes from moving focus to it, not from a live region, so it does not
+      need to pre-exist in the accessibility tree. */}
   <p
     data-prereg-success
     hidden
@@ -164,25 +168,40 @@ const inputClass =
       form.querySelector<HTMLElement>(`[data-error-for="${name}"]`);
 
     const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    /** Whatever they type, the wire format is E.164 — the endpoint dedupes on
-     *  an exact string match, and every existing row was written as +1XXXXXXXXXX.
+
+    /** Whatever they type, the wire format is E.164 — the endpoint dedupes on an
+     *  exact string match, so two spellings of one number are two people to it.
      *
-     *  Only formatting characters are stripped, never letters or stray digits.
-     *  Discarding every non-digit was worse than useless here: it turned
-     *  "+1-305-555-0100 ext 2" into the valid-looking +130555501002 — a number
-     *  that does not exist, and a second whitelist row for someone already
-     *  stored as +13055550100, which is the exact duplicate the endpoint's
-     *  dedupe exists to prevent. */
-    const e164 = (raw: string) => raw.trim().replace(/[\s().\-‐-―]/g, "");
-    // E.164: "+", a country code that cannot start with 0, then up to 15 digits
-    // in total. "+001 305…" is a dialling prefix, not a country code.
+     *  Strips formatting only (spaces incl. NBSP, brackets, dots, and the ASCII
+     *  and Unicode dashes), never letters or digits. A bare 10-digit number gets
+     *  the +1 the old form used to force, so a phone autofilled as
+     *  "(305) 555-0100" still normalises instead of landing on a red error. */
+    const e164 = (raw: string) => {
+      const stripped = raw.trim().replace(/[\s ().\-‐-―]/g, "");
+      return /^\d{10}$/.test(stripped) ? `+1${stripped}` : stripped;
+    };
+
+    /** E.164 shape: "+", a country code that cannot start with 0, 10–15 digits
+     *  total — so "+001 305…", a dialling prefix, is not a country code.
+     *
+     *  NANP (+1) is pinned to exactly 11 digits, and that is the whole point
+     *  rather than a nicety. The general 10–15 range accepts BOTH a US number
+     *  with a digit dropped and a US number with an extension run onto the end:
+     *  "+1 305 555 0100 2" reads as valid, and writes a second row beside the
+     *  same person's +13055550100. Stripping only formatting characters does not
+     *  catch that on its own — the stray character is a digit. */
     const PHONE = /^\+[1-9]\d{9,14}$/;
+    const NANP = /^\+1\d{10}$/;
+    const validPhone = (raw: string) => {
+      const n = e164(raw);
+      return n.startsWith("+1") ? NANP.test(n) : PHONE.test(n);
+    };
 
     /** Per-field validation, copy-map §2.2. Returns the message, or null. */
     function validate(name: string, value: string): string | null {
       if (!value.trim()) return t.required;
       if (name === "email" && !EMAIL.test(value.trim())) return t.badEmail;
-      if (name === "phoneNumber" && !PHONE.test(e164(value))) return t.badPhone;
+      if (name === "phoneNumber" && !validPhone(value)) return t.badPhone;
       return null;
     }
 


### PR DESCRIPTION
A second independent review (standards + spec + adversarial) of the **merged** #37 work — PR #58's own fix commit `f878966` had never been reviewed by anyone. Follow-up to [#37](https://github.com/yeapptech/yeride-website/issues/37).

## The phone fix in #58 did not close the bug it claimed to

`f878966` changed normalisation to strip **formatting characters only**. That stops `"+1-305-555-0100 ext 2"` — because the stray character is a *letter*. It does nothing about:

```
"+1 305 555 0100 2"  ->  +130555501002   ACCEPTED
```

The stray character is a digit, so it survives stripping, passes the 10–15 digit E.164 range, and writes **a second `whitelist` row beside the same person's `+13055550100`** — the exact duplicate the endpoint's dedupe exists to prevent, and the exact failure the previous commit message claims to have fixed. The same loose range accepted `"+1 305 555 010"`, a US number one digit short.

**Fix:** `+1` is pinned to exactly 11 digits (NANP); other country codes keep the general E.164 range.

**Also fixed, same rule:** a bare 10-digit number now gets the `+1` the old form used to force. Previously every national-format autofill — `(305) 555-0100`, `3055550100`, `305-555-0100`, which is what iOS/Android `autocomplete="tel"` delivers — was **rejected with a red error**. That was a live conversion risk on both audience pages.

**Verified against the shipped bundle in a browser**, not against a copy of the regex — that is how the last fix passed a unit check and still shipped broken:

| input | before | now |
|---|---|---|
| `+1 305 555 0100 2` | accepted → duplicate row | rejected |
| `+1 305 555 010` | accepted | rejected |
| `+1 305 555 01000` | accepted | rejected |
| `+001 305 555 0100` | rejected | rejected |
| `(305) 555-0100` | **rejected** | accepted → `+13055550100` |
| `3055550100` | **rejected** | accepted → `+13055550100` |
| `+34 612 34 56 78` | accepted | accepted |

Ten cases, zero failures, and a real submit confirmed `(305) 555-0100` reaches the wire as `+13055550100`.

## Documentation that was false

All pre-redesign text that survived because nobody re-read it. The review caught it because #37 rewrote `docs/components.md` and so appeared to own it.

- **`docs/components.md`** documented `navBar.astro` (deleted in #35), a `Header` with Home/About/Contact/Pre-Register and a hamburger menu, `<Header />` and `<BaseLayout title=…>` usage that **would fail `astro check`** (`toggleHref` is required; four `BaseLayout` props were undocumented), and a green/grey palette that no longer exists in the build.
- **`CLAUDE.md`** still said `404.astro` was the only `BaseLayout` page, `index.astro` was self-contained with inline header and footer, four pages loaded CDN Tailwind, and the site linked Inter from Google Fonts.

## One thing the review taught me about this repo

There is **no `.gitattributes`** and line endings are mixed — 16 of 56 tracked text files are CRLF. My `docs/components.md` edit in #58 rewrote a CRLF file with a tool that emits LF, converting all 323 lines and burying the real change in a full-file diff. That is now written down in `CLAUDE.md`. Normalising the repo would be its own change, not this one.

## Not fixed here

- `/es/riders` links to `/es/fare-estimate`, which 404s until #38. Tracked by the route-parity `PENDING` map and required empty by #42.
- The copy map's E.164 claim was over-stated; scoped down on `copy-map/en-es` (`37b826b`) — rows created *through this site* are `+1XXXXXXXXXX`, but nothing was read from the database.
- `PUBLIC_API_URL` build-time inlining — #59.
- API CORS omits `www.yeride.com` — yeride-admin-api#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)