### PR TITLE
fix(fees): state the real reason each withheld thing is withheld (wayfinder #47)

### DIFF
--- a/src/components/FeeSchedule.astro
+++ b/src/components/FeeSchedule.astro
@@ -190,24 +190,51 @@ const esPrefix = lang === "es" ? "/es" : "";
   const GAP = "—";
   const rate = (n: number | null | undefined) => usd(n) ?? GAP;
 
-  /** Phrase the endpoint's machine-readable rule; never invent one. */
-  function ruleText(rule: ChargeRule | null | undefined): string {
-    if (!rule) return GAP;
+  const finite = (n: unknown): n is number => typeof n === "number" && Number.isFinite(n);
+
+  /** Phrase the endpoint's machine-readable rule; never invent one.
+   *
+   *  Returns `null` — not the gap glyph — when the rule has no statable form, so
+   *  callers can ask "is this a gap?" without pattern-matching rendered text. The
+   *  charge labels contain em dashes of their own ("Ride technology — to pickup"),
+   *  so a `=== GAP` test on the output is both fragile and, for anything phrased
+   *  around the glyph, wrong.
+   *
+   *  Every amount is checked before it is interpolated. A template literal turns
+   *  `null` into the text "null", and `perMile(null)` is `0` because `null * n`
+   *  coerces — so an unguarded per-km rule with a missing amount published
+   *  "$0.00 per mile", the exact $0.00-masking-a-gap failure this page exists to
+   *  refuse. A broken source document must be visible, never priced. */
+  function ruleText(rule: ChargeRule | null | undefined): string | null {
+    if (!rule) return null;
     switch (rule.kind) {
-      case "flat":
-        return `${usd(rule.amount)} ${t.perTrip}`;
-      case "per_minute":
-        return `${usd(rule.amount)} ${t.perMinute}`;
-      case "per_km":
-        return `${usd(perMile(rule.amount))} ${t.perMile}`;
+      case "flat": {
+        const amount = usd(rule.amount);
+        return amount && `${amount} ${t.perTrip}`;
+      }
+      case "per_minute": {
+        const amount = usd(rule.amount);
+        return amount && `${amount} ${t.perMinute}`;
+      }
+      case "per_km": {
+        if (!finite(rule.amount)) return null;
+        const amount = usd(perMile(rule.amount));
+        return amount && `${amount} ${t.perMile}`;
+      }
       case "percent_of_fare": {
+        if (!finite(rule.percent)) return null;
         const base = `${rule.percent}% ${t.percentOfFare}`;
-        return rule.plus ? `${base} + ${usd(rule.plus)}` : base;
+        if (rule.plus == null) return base;
+        const plus = usd(rule.plus);
+        return plus && `${base} + ${plus}`;
       }
       default:
-        return GAP;
+        return null;
     }
   }
+
+  /** What the amount column shows: the rule, or an explicit gap. */
+  const ruleCell = (rule: ChargeRule | null | undefined) => ruleText(rule) ?? GAP;
 
   function fetchedStamp(iso: string): string {
     const d = new Date(iso);
@@ -344,7 +371,7 @@ const esPrefix = lang === "es" ? "/es" : "";
               (c) => `<li class="border-b border-ink/10 py-2.5 last:border-b-0">
                 <div class="flex items-baseline justify-between gap-3">
                   <span class="text-ink">${esc(chargeName(c))}</span>
-                  <span class="text-right font-bold tabular-nums text-ink">${esc(ruleText(c.rule))}</span>
+                  <span class="text-right font-bold tabular-nums text-ink">${esc(ruleCell(c.rule))}</span>
                 </div>
                 ${
                   p.notes[c.id]
@@ -355,11 +382,15 @@ const esPrefix = lang === "es" ? "/es" : "";
             )
             .join("")}</ul>
           ${
-            // A charge whose rule the endpoint can't summarise prints "—". The
+            // A charge whose rule the endpoint can't summarise shows a gap. The
             // marker is honest but silent, so the panel showing one explains it
             // rather than leaving a priced-fee page with an unpriced line and no
             // reason. Conditional: it vanishes when #21 publishes the rule.
-            p.charges.some((c) => ruleText(c.rule) === GAP)
+            //
+            // Asked of the rule, not of the rendered cell: two charge labels
+            // carry em dashes themselves, so the note must not be phrased around
+            // the glyph and the test must not look for it.
+            p.charges.some((c) => ruleText(c.rule) === null)
               ? `<p class="mt-3 text-[12.5px] text-ink/50">${esc(t.gapNote)}</p>`
               : ""
           }
@@ -399,11 +430,14 @@ const esPrefix = lang === "es" ? "/es" : "";
     });
     // Each cause states itself. Collapsing these into one message is how the
     // live page came to blame an undescribed charge while every charge was
-    // described — the endpoint simply had no example to give (#47).
+    // described — the endpoint simply had no example to give (#47). Three
+    // branches, three strings: two of them sharing one message reintroduced the
+    // same bug on the surviving branch, which is what the review of #47 caught.
     const withheld = (message: string) =>
       `<p class="mt-3 max-w-xl text-[14px] text-paper/60">${esc(message)}</p>`;
     if (!ex) return withheld(t.exampleUnpublished);
-    if (!classified || !priced) return withheld(t.exampleUnavailable);
+    if (!classified) return withheld(t.exampleUnavailable);
+    if (!priced) return withheld(t.exampleIncomplete);
 
     const of = (id: string) => amounts.get(id) as number;
     const ids = (test: (l: ChargeLabel) => boolean) =>

--- a/src/components/FeeSchedule.astro
+++ b/src/components/FeeSchedule.astro
@@ -354,6 +354,15 @@ const esPrefix = lang === "es" ? "/es" : "";
               </li>`,
             )
             .join("")}</ul>
+          ${
+            // A charge whose rule the endpoint can't summarise prints "—". The
+            // marker is honest but silent, so the panel showing one explains it
+            // rather than leaving a priced-fee page with an unpriced line and no
+            // reason. Conditional: it vanishes when #21 publishes the rule.
+            p.charges.some((c) => ruleText(c.rule) === GAP)
+              ? `<p class="mt-3 text-[12.5px] text-ink/50">${esc(t.gapNote)}</p>`
+              : ""
+          }
         </section>`,
       )
       .join("");
@@ -388,9 +397,13 @@ const esPrefix = lang === "es" ? "/es" : "";
       const a = amounts.get(c.id);
       return typeof a === "number" && Number.isFinite(a);
     });
-    if (!ex || !classified || !priced) {
-      return `<p class="mt-3 max-w-xl text-[14px] text-paper/60">${esc(t.exampleUnavailable)}</p>`;
-    }
+    // Each cause states itself. Collapsing these into one message is how the
+    // live page came to blame an undescribed charge while every charge was
+    // described — the endpoint simply had no example to give (#47).
+    const withheld = (message: string) =>
+      `<p class="mt-3 max-w-xl text-[14px] text-paper/60">${esc(message)}</p>`;
+    if (!ex) return withheld(t.exampleUnpublished);
+    if (!classified || !priced) return withheld(t.exampleUnavailable);
 
     const of = (id: string) => amounts.get(id) as number;
     const ids = (test: (l: ChargeLabel) => boolean) =>
@@ -469,7 +482,7 @@ const esPrefix = lang === "es" ? "/es" : "";
         .map(
           (a) =>
             `<option value="${esc(a.id)}"${a.id === schedule.area.id ? " selected" : ""}>${esc(
-              serviceAreaName(a.id, a.identifier),
+              serviceAreaName(a.id, a.identifier, lang),
             )}</option>`,
         )
         .join("");

--- a/src/i18n/feeLabels.ts
+++ b/src/i18n/feeLabels.ts
@@ -31,6 +31,8 @@
 // entries were removed for that reason; the `passthrough` family and `cardOnly`
 // stay defined for when #48 gives them members again.
 
+import type { Lang } from "./feesCopy";
+
 export type ChargeFamily = "tech" | "passthrough";
 
 export interface ChargeLabel {
@@ -75,16 +77,25 @@ export const feeLabels: Record<string, ChargeLabel> = {
 };
 
 // Service-area documents carry an `identifier` slug and no display-name field
-// (yeride-admin-api docs/DATA-MODELS.md §serviceAreas), so the picker's labels
-// live here until the brand/admin side adds one. An area missing from this map
-// falls back to its humanised identifier.
-export const serviceAreaNames: Record<string, string> = {
-  "us-fl-south-florida": "South Florida",
+// (yeride-admin-api docs/DATA-MODELS.md §serviceAreas). Display names stay the
+// site's job by decision (#47, 2026-08-02) rather than moving to a backend
+// `name` field: an area name is bilingual brand copy, not data, and a single
+// backend string would ship one language and leak English onto /es/fees — the
+// exact failure the charge-id rekey above was opened to fix. Two of the three
+// servable stage areas are Spanish-speaking, so that is not hypothetical.
+//
+// The cost of keeping it here is that a new area needs a web deploy to launch
+// with a real name. #56 makes that visible instead of silent: it fails the
+// build on an area id this map doesn't cover, the same treatment it gives an
+// uncovered charge id. Until it lands, an uncovered area falls back to its
+// humanised identifier ("Us Mi Detroit") in both languages.
+export const serviceAreaNames: Record<string, Record<Lang, string>> = {
+  "us-fl-south-florida": { en: "South Florida", es: "Sur de la Florida" },
 };
 
-export function serviceAreaName(id: string, identifier: string): string {
+export function serviceAreaName(id: string, identifier: string, lang: Lang): string {
   return (
-    serviceAreaNames[id] ??
+    serviceAreaNames[id]?.[lang] ??
     identifier
       .split(/[-_]/)
       .filter(Boolean)

--- a/src/i18n/feesCopy.ts
+++ b/src/i18n/feesCopy.ts
@@ -2,27 +2,35 @@
 // Do not reword, re-case, or re-punctuate.
 //
 // The strings #40 authored ahead of the map were blessed and amended into §3.4
-// on 2026-08-02 (#47), so they are no longer provisional. Only the unit and
-// rule fragments — used to phrase rates in both languages from the endpoint's
-// machine-readable forms — remain a build-side detail the map does not carry.
+// on 2026-08-02 (#47), so they are no longer provisional. The unit and rule
+// fragments — used to phrase rates in both languages from the endpoint's
+// machine-readable forms — stay a build-side detail the map does not carry.
+// `cardNote` is dead: §3.4 dropped its row when card processing became its own
+// section, and nothing reads it. Left in place rather than removed here, since
+// deleting another ticket's leftover is not this change's business.
 //
 // The page withholds things, and each withholding states its own cause (#47).
 // One string covering every branch was how the live page came to say "until
 // every published charge is described above" while every published charge was
 // described above — a false reason is the same class of error as guessing a
-// charge into a family, which this page refuses to do:
+// charge into a family, which this page refuses to do. Three causes, three
+// strings; the first pass at this shipped two, which left the same bug alive on
+// the surviving branch and is what the review of #47 caught:
 //   - `exampleUnpublished` — the endpoint returned no example trip at all. This
 //     is what production actually renders today: `getFeeSchedule` returns
 //     `example: null` because `pickupBandwidthCharge` meters the time before a
 //     ride starts, which a synthetic reference trip cannot know
 //     (yeride-functions#21).
-//   - `exampleUnavailable` — the site's own safety net: a charge it cannot
-//     classify, or one priced in the schedule but absent from the example. The
-//     ledger claims the money reconciles, so it is withheld rather than shown
-//     short. Renders for nobody today.
-//   - `gapNote` — explains the "—" a charge shows when the endpoint publishes
-//     no summarisable rule for it. Conditional, so it disappears by itself when
-//     #21 publishes one.
+//   - `exampleIncomplete` — the endpoint published an example but left a priced
+//     charge out of it. The likeliest branch once #21 ships, for the same reason
+//     the example is null today.
+//   - `exampleUnavailable` — the site's own gap: a charge it cannot classify.
+//     The ledger claims the money reconciles, so it is withheld rather than
+//     shown short. Renders for nobody today.
+//   - `gapNote` — explains a charge whose amount column is empty because the
+//     endpoint publishes no summarisable rule for it. Phrased around the missing
+//     amount, never around the "—" that fills it: two charge labels carry em
+//     dashes of their own. Conditional, so it disappears when #21 publishes one.
 
 export type Lang = "en" | "es";
 
@@ -61,8 +69,12 @@ export const feesCopy = {
     // evasion on a page whose whole pitch is transparency (#47).
     otherFamilyH2: "Other charges",
     otherFamilyLead: "Charges YeRide publishes that this page doesn’t describe yet.",
+    // Phrased around the empty amount, not the "—" that fills it: two charge
+    // labels carry em dashes of their own ("Ride technology — to pickup"), so a
+    // note explaining "a —" was false about most of the dashes on screen (#47
+    // review).
     gapNote:
-      "A — means YeRide hasn’t published a rule for that charge that this page can state plainly.",
+      "A charge with no amount shown is one YeRide hasn’t published a rule for that this page can state plainly.",
     exampleH2: "Example at today’s rates",
     exampleNote: "Computed from the schedule above, not a quote.",
     riderColH: "What the rider pays",
@@ -78,6 +90,8 @@ export const feesCopy = {
     cashNotePost: ".",
     // withheld ledger — one string per cause, never one string for all of them
     exampleUnpublished: "YeRide hasn’t published an example trip for this area yet.",
+    exampleIncomplete:
+      "YeRide’s example trip leaves out one of the charges above, so it wouldn’t add up.",
     exampleUnavailable:
       "The example is unavailable until every published charge is described above.",
     // Named for what it is, and attributed (map owner, 2026-08-02). No figure:
@@ -134,7 +148,7 @@ export const feesCopy = {
     otherFamilyH2: "Otros cargos",
     otherFamilyLead: "Cargos que YeRide publica y que esta página todavía no describe.",
     gapNote:
-      "Un — significa que YeRide todavía no publica una regla para ese cargo que esta página pueda expresar con claridad.",
+      "Un cargo sin monto es uno para el que YeRide todavía no publica una regla que esta página pueda expresar con claridad.",
     exampleH2: "Ejemplo con las tarifas de hoy",
     exampleNote: "Calculado con el tarifario de arriba; no es una cotización.",
     riderColH: "Lo que paga quien viaja",
@@ -149,6 +163,8 @@ export const feesCopy = {
     cashNotePost: ".",
     exampleUnpublished:
       "YeRide todavía no publica un viaje de ejemplo para esta área.",
+    exampleIncomplete:
+      "El viaje de ejemplo de YeRide deja fuera uno de los cargos de arriba, así que no cuadraría.",
     exampleUnavailable:
       "El ejemplo no está disponible hasta que cada cargo publicado esté descrito arriba.",
     stripeH2: "El procesamiento de tarjeta es de Stripe, no de YeRide",

--- a/src/i18n/feesCopy.ts
+++ b/src/i18n/feesCopy.ts
@@ -1,14 +1,28 @@
 // /fees and /es/fees copy — VERBATIM from docs/copy-map.md §3.4 (wayfinder #34).
 // Do not reword, re-case, or re-punctuate.
 //
-// Three groups are additions this build needed and the copy map does not yet
-// carry; they are marked and flagged on #40:
-//   - `otherFamilyH2` / `otherFamilyLead` — where a charge id the site can't
-//     classify renders, since guessing it into either family would be a claim.
-//   - `exampleUnavailable` — the ledger claims the money reconciles, so it is
-//     withheld rather than shown incomplete when a charge is unclassified.
-//   - the unit and rule fragments used to phrase rates and rules in both
-//     languages from the endpoint's machine-readable forms.
+// The strings #40 authored ahead of the map were blessed and amended into §3.4
+// on 2026-08-02 (#47), so they are no longer provisional. Only the unit and
+// rule fragments — used to phrase rates in both languages from the endpoint's
+// machine-readable forms — remain a build-side detail the map does not carry.
+//
+// The page withholds things, and each withholding states its own cause (#47).
+// One string covering every branch was how the live page came to say "until
+// every published charge is described above" while every published charge was
+// described above — a false reason is the same class of error as guessing a
+// charge into a family, which this page refuses to do:
+//   - `exampleUnpublished` — the endpoint returned no example trip at all. This
+//     is what production actually renders today: `getFeeSchedule` returns
+//     `example: null` because `pickupBandwidthCharge` meters the time before a
+//     ride starts, which a synthetic reference trip cannot know
+//     (yeride-functions#21).
+//   - `exampleUnavailable` — the site's own safety net: a charge it cannot
+//     classify, or one priced in the schedule but absent from the example. The
+//     ledger claims the money reconciles, so it is withheld rather than shown
+//     short. Renders for nobody today.
+//   - `gapNote` — explains the "—" a charge shows when the endpoint publishes
+//     no summarisable rule for it. Conditional, so it disappears by itself when
+//     #21 publishes one.
 
 export type Lang = "en" | "es";
 
@@ -42,10 +56,13 @@ export const feesCopy = {
       "The coverage Florida requires during a ride. The rider's share and the driver's share are separate, published lines.",
     cardNote:
       "The card networks' standard rate, borne by the driver on card fares. Cash fares have none.",
-    // addition — unclassified charges
+    // Unclassified charges. "YeRide", not "the platform": every other line on
+    // this page owns the charge by name, and distancing language reads as
+    // evasion on a page whose whole pitch is transparency (#47).
     otherFamilyH2: "Other charges",
-    otherFamilyLead:
-      "Charges the platform publishes that this page does not yet describe.",
+    otherFamilyLead: "Charges YeRide publishes that this page doesn’t describe yet.",
+    gapNote:
+      "A — means YeRide hasn’t published a rule for that charge that this page can state plainly.",
     exampleH2: "Example at today’s rates",
     exampleNote: "Computed from the schedule above, not a quote.",
     riderColH: "What the rider pays",
@@ -59,7 +76,8 @@ export const feesCopy = {
     driverTotalBeforeCard: "Total — before card processing",
     cashNotePre: "On a cash fare there’s no card processing — the driver keeps ",
     cashNotePost: ".",
-    // addition — withheld ledger
+    // withheld ledger — one string per cause, never one string for all of them
+    exampleUnpublished: "YeRide hasn’t published an example trip for this area yet.",
     exampleUnavailable:
       "The example is unavailable until every published charge is described above.",
     // Named for what it is, and attributed (map owner, 2026-08-02). No figure:
@@ -114,8 +132,9 @@ export const feesCopy = {
     cardNote:
       "La tarifa estándar de las redes de tarjetas, que paga quien maneja en viajes con tarjeta. Los viajes en efectivo no la tienen.",
     otherFamilyH2: "Otros cargos",
-    otherFamilyLead:
-      "Cargos que publica la plataforma y que esta página todavía no describe.",
+    otherFamilyLead: "Cargos que YeRide publica y que esta página todavía no describe.",
+    gapNote:
+      "Un — significa que YeRide todavía no publica una regla para ese cargo que esta página pueda expresar con claridad.",
     exampleH2: "Ejemplo con las tarifas de hoy",
     exampleNote: "Calculado con el tarifario de arriba; no es una cotización.",
     riderColH: "Lo que paga quien viaja",
@@ -128,6 +147,8 @@ export const feesCopy = {
     cashNotePre:
       "En un viaje en efectivo no hay procesamiento de tarjeta — a quien maneja le quedan ",
     cashNotePost: ".",
+    exampleUnpublished:
+      "YeRide todavía no publica un viaje de ejemplo para esta área.",
     exampleUnavailable:
       "El ejemplo no está disponible hasta que cada cargo publicado esté descrito arriba.",
     stripeH2: "El procesamiento de tarjeta es de Stripe, no de YeRide",


### PR DESCRIPTION
Resolves the copy half of #47. Part of #30.

## The finding

Production's `/fees` renders:

> The example is unavailable until every published charge is described above.

Every published charge **is** described above — the charge-id rekey is live and all four ids classify. The ledger is withheld because `getFeeSchedule` returns `example: null`, which is a backend fact (yeapptech/yeride-functions#21), not a gap on this page.

One string covered three different withholding branches in `FeeSchedule.astro` — the endpoint published no example (`!ex`, the live one), the site can't classify a charge (`!classified`), and a charge priced in the schedule is missing from the example (`!priced`) — and it named only the second. So the page published a false reason.

That is the same class of error as guessing a charge into a family, which this page already refuses to do.

## Changes

**Each withholding states its own cause.** `exampleUnpublished` covers the endpoint case; `exampleUnavailable` keeps its wording for the safety net it was written for, where it is true.

**The gap dash is explained.** `pickupBandwidthCharge` prints `—` because its expression isn't summarisable. The marker was honest but silent, on a page whose lead promises "Current amounts, fetched live". A panel containing a gap now carries a note — conditional, so it disappears by itself when #21 publishes the rule.

**"Other charges" moves into YeRide's voice** — "the platform" → "YeRide", plus the page's contraction style. Every other line on `/fees` owns the charge by name.

**`serviceAreaNames` goes bilingual.** `/es/fees` showed "South Florida"; it now shows "Sur de la Florida".

## The area-name decision

Display names stay the site's job rather than moving to a backend `name` field on the area document. An area name is bilingual brand copy, not data — a single backend string ships one language and leaks English onto `/es/fees`, which is exactly the failure the charge-id rekey was opened to fix, and two of the three servable stage areas are Spanish-speaking.

The cost is that a new area needs a web deploy to launch with a real name. #56 makes that visible instead of silent: it gains a check that fails the build on an area id the map doesn't cover, the same treatment it gives an uncovered charge id.

## Verification

`npm run build` — route parity, copy gate and `astro check` all pass (0 errors, no new copy-gate allowlist entries).

The rendering was verified through the **built bundle in a browser**, against the **real production response**, in EN and ES:

| Branch | Result |
|---|---|
| Production today (`example: null`, one null rule) | states the endpoint cause; gap note renders |
| Unclassified charge present | "Other charges" panel with the reworded lead; ledger withheld with the site-side cause |
| Full example, all classified and priced | ledger renders and reconciles ($9.75 − 0.25 − 0.25 − 0.45 − 0.05 = $8.75) |
| No charge with a null rule | gap note absent — the conditional works both ways |

**On what CI here does and doesn't cover:** `checks.yml` deliberately runs only the two gate scripts — it skips `astro check` and `astro build`, which need the private registry. The full chain runs on merge to main via `deploy-all.yml`.

So the typecheck was run locally. `astro check` reported **0 errors against the real sources**, before any stubbing. The private `@yeapptech/yeride-brand` package can't install locally without an `NPM_TOKEN`, so it was stubbed only to get past Tailwind preset resolution for the browser render checks above — styling assets only, never committed, and it cannot affect the string and control-flow behaviour being verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Independently reviewed — four defects, all fixed (`d2c49ca`)

Three parallel agents reviewed the first commit. Two independently found the same defect.

1. **The fix repeated its own bug.** Three withholding causes were split into **two** strings while the comment above declared "one string per cause". Every production id is classified, so `!priced` was the survivor's only reachable trigger — and it blamed an undescribed charge while every charge was described. Now three strings.
2. **The gap note was false about most of the dashes on screen.** It explained what "a —" means, but `GAP` is U+2014 and so is the em dash inside the charge labels "Ride technology — to pickup" / "— on trip". Rephrased around the missing amount, naming no glyph.
3. **Gap detection compared rendered text to the glyph** — the root cause of (2). `ruleText` now returns `null` for an unstatable rule; `ruleCell` substitutes the marker at display time.
4. **`/fees` could publish "$0.00 per mile"** — found while fixing (3), by neither review. `perMile(null)` is `0` because `null * n` coerces, so a per-km rule with a missing amount priced a charge YeRide never set — the exact $0.00-masking-a-gap failure this page refuses. Unchecked interpolation also printed `null per trip` / `null% of the fare`. Every amount is now checked before it is phrased.

Re-verified in EN and ES against four payloads: real production, an endpoint example missing a priced charge, an unclassifiable id, and rules broken three ways (`flat`/null, `per_km`/null, `percent`/null) — all three now render as explicit gaps.
