### PR TITLE
Fee-label coverage against the live endpoint (wayfinder #56)

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -36,6 +36,14 @@ jobs:
           echo "PUBLIC_FIREBASE_PROJECT_ID=${{ secrets.PUBLIC_FIREBASE_PROJECT_ID }}" >> .env
           echo "PUBLIC_FEE_SCHEDULE_URL=${{ secrets.PUBLIC_FEE_SCHEDULE_URL }}" >> .env
 
+      # Fee-label coverage (#56). Needs the network, so it is not part of
+      # `npm run build` — see the script header. Fails the deploy on a charge or
+      # area id the site cannot name; skips, loudly, if the endpoint is down.
+      - name: Fee-label coverage
+        env:
+          PUBLIC_FEE_SCHEDULE_URL: ${{ secrets.PUBLIC_FEE_SCHEDULE_URL }}
+        run: node scripts/check-fee-labels.mjs
+
       - name: Install dependencies
         # NPM_TOKEN: org read-only classic PAT with read:packages — the
         # committed .npmrc routes @yeapptech/* through GitHub Packages

--- a/.github/workflows/fee-label-drift.yml
+++ b/.github/workflows/fee-label-drift.yml
@@ -1,0 +1,66 @@
+# Fee-label drift — daily (wayfinder #56).
+#
+# deploy-all.yml already runs this check before every deploy, but drift does not
+# arrive with a deploy: someone files a new charge or opens a new service area in
+# the admin console, and this site can go weeks without a push. Between releases
+# the only thing that notices is a schedule.
+#
+# The run fails AND opens an issue. The red run is the notification; the issue is
+# the durable, assignable artifact, and it says exactly what a human has to
+# decide (family and payer are editorial, not data).
+
+name: Fee-label drift
+
+on:
+  schedule:
+    # 13:17 UTC — off the hour, so it is not queued behind the top-of-hour rush.
+    - cron: "17 13 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Fee-label coverage
+        id: check
+        env:
+          PUBLIC_FEE_SCHEDULE_URL: ${{ secrets.PUBLIC_FEE_SCHEDULE_URL }}
+        run: |
+          node scripts/check-fee-labels.mjs 2>&1 | tee report.txt
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Open an issue on drift
+        if: steps.check.outputs.status != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Fee-label drift: getFeeSchedule publishes an id the site cannot name"
+        run: |
+          # Searched on the phrase, not the whole title: the colon in it is
+          # search syntax to GitHub and would match nothing.
+          open=$(gh issue list --state open --search '"Fee-label drift" in:title' --json number --jq '.[0].number // empty')
+          if [ -n "$open" ]; then
+            echo "Already tracked in #$open — commenting instead."
+            gh issue comment "$open" --body "Still drifting as of $(date -u +%FT%TZ):
+
+          \`\`\`
+          $(cat report.txt)
+          \`\`\`"
+          else
+            gh issue create --title "$TITLE" --body "\`getFeeSchedule\` is publishing a charge id or service area that \`src/i18n/feeLabels.ts\` does not cover, so \`/es/fees\` would print English (a charge) or a humanised slug (an area), and an unclassified charge withholds the example ledger on \`/fees\` entirely.
+
+          Found by the daily [fee-label drift check](https://github.com/${{ github.repository }}/actions/workflows/fee-label-drift.yml) (wayfinder #56). It also runs before every deploy, so **the site cannot ship until this is closed.**
+
+          \`\`\`
+          $(cat report.txt)
+          \`\`\`"
+          fi
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ No test runner and no linter are configured. `npm run build` is the only automat
 
 `.github/workflows/checks.yml` runs items 1–2 on every pull request; `deploy-all.yml` runs the full chain on `main` and gates deployment on it.
 
+One further gate runs **outside `npm run build`**, because it needs the network:
+
+- **`scripts/check-fee-labels.mjs`** — every charge id and service area `getFeeSchedule` publishes has a site-authored EN/ES label in `src/i18n/feeLabels.ts`. It asks the live endpoint (all areas, not just the default), so it cannot live in `npm run checks` without coupling every local build and every PR to a third party's uptime. It runs on deploy (`deploy-all.yml`, before the build) and daily on a schedule (`fee-label-drift.yml`, which opens an issue on drift, since drift arrives from the admin console between deploys). It **fails on drift and skips when it cannot ask** — a missing `PUBLIC_FEE_SCHEDULE_URL` or an unreachable endpoint prints a `SKIPPED` line and exits 0. Run it by hand with `node scripts/check-fee-labels.mjs [url]`.
+
 ## Environment Variables
 
 All six are `PUBLIC_` (client-side) and are injected in CI from GitHub Secrets. Create a `.env` for local development:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "checks": "node scripts/check-route-parity.mjs && node scripts/check-copy-gate.mjs",
+    "check:fee-labels": "node scripts/check-fee-labels.mjs",
     "build": "npm run checks && astro check && astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/scripts/check-fee-labels.mjs
+++ b/scripts/check-fee-labels.mjs
@@ -1,0 +1,212 @@
+// Fee-label coverage — every charge id and every service area `getFeeSchedule`
+// publishes has site-authored EN/ES copy, or the deploy fails.
+// Wayfinder #56; the rule is docs/copy-map.md §6.2, extended to service areas
+// by #47.
+//
+// Unlike the other two gates this one is NOT offline and NOT dumb: it asks the
+// endpoint what it is publishing right now. That is the whole point — the ids
+// live in Firestore documents in another system, so nothing in this repo can
+// answer the question. #41 filed the check and could not build it for exactly
+// this reason.
+//
+// WHERE IT RUNS, and why not in `npm run build` (#56's first sub-question):
+// putting a network call in `npm run checks` would make every local build and
+// every PR depend on a third-party function being up, which is the opposite of
+// the dependency-free rule the other two follow. It runs instead
+//   - on deploy (deploy-all.yml), where PUBLIC_FEE_SCHEDULE_URL already exists;
+//   - daily on a schedule (fee-label-drift.yml), because drift is introduced
+//     upstream — someone files a new charge in the admin console — and this site
+//     deploys rarely. Deploy-time-only checking would let /es/fees leak English
+//     for weeks between releases.
+//
+// FAILS ON DRIFT, SKIPS WHEN IT CANNOT ASK. An id the site cannot name is a real
+// defect this repo can fix, and it blocks the deploy. An endpoint that did not
+// answer is not — blocking an unrelated content fix on someone else's uptime
+// would be the wrong trade, and a schedule the page cannot fetch already renders
+// /fees' designed error state rather than a wrong number.
+//
+// WHAT IT CANNOT DO: it checks that a label EXISTS, never that it is right.
+// `family` and `payer` are editorial — neither is a database field — so for a new
+// id this can only say that a human must classify it.
+
+import { readFileSync, existsSync } from "node:fs";
+
+const LABELS = "src/i18n/feeLabels.ts";
+const TIMEOUT_MS = 10_000;
+
+// The same variable the site is built against, so the check reads exactly the
+// data the shipped page will fetch. An argument overrides it for manual runs
+// against another environment.
+const endpoint =
+  process.argv[2] || process.env.PUBLIC_FEE_SCHEDULE_URL || fromDotEnv();
+
+function fromDotEnv() {
+  if (!existsSync(".env")) return "";
+  const line = readFileSync(".env", "utf8")
+    .split("\n")
+    .find((l) => l.startsWith("PUBLIC_FEE_SCHEDULE_URL="));
+  return line ? line.slice(line.indexOf("=") + 1).trim() : "";
+}
+
+function skip(why) {
+  console.log(`- fee labels SKIPPED — ${why}`);
+  console.log(`  Nothing was checked: ids the site cannot name would not be seen.`);
+  process.exit(0);
+}
+
+/** Top-level keys of an exported object literal, read out of the TypeScript
+ *  source. Reading source text is what the other two gates do; it keeps this
+ *  dependency-free and avoids compiling TS to learn four strings. */
+function objectKeys(src, exportName) {
+  const decl = new RegExp(`export const ${exportName}\\b[^=]*=\\s*\\{`).exec(src);
+  if (!decl) throw new Error(`${LABELS} has no "export const ${exportName}"`);
+
+  let depth = 0;
+  let top = ""; // depth-1 text only; nested objects collapse to nothing
+  let str = null;
+  for (let i = decl.index + decl[0].length - 1; i < src.length; i++) {
+    const c = src[i];
+    if (str) {
+      // Quoted keys are keys — `"us-fl-south-florida":` has to survive the skip.
+      // Punctuation inside the quotes is neutralised so a string value can never
+      // look like the start of another entry.
+      if (depth === 1) top += /[,:{}]/.test(c) ? " " : c;
+      if (c === "\\") i++;
+      else if (c === str) str = null;
+      continue;
+    }
+    // Comments are skipped, not scanned. They are prose: an apostrophe in
+    // "the driver's side" would otherwise open a string that never closes, and
+    // a comment between two entries would hide the second key from the match.
+    if (c === "/" && src[i + 1] === "/") {
+      i = src.indexOf("\n", i);
+      if (i === -1) break;
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "*") {
+      const end = src.indexOf("*/", i + 2);
+      if (end === -1) break;
+      i = end + 1;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      str = c;
+      if (depth === 1) top += c;
+      continue;
+    }
+    if (c === "{") {
+      depth++;
+      continue;
+    }
+    if (c === "}") {
+      depth--;
+      if (depth === 0) break;
+      continue;
+    }
+    if (depth === 1) top += c;
+  }
+  if (depth !== 0) throw new Error(`${LABELS}: ${exportName} literal is unbalanced`);
+
+  return new Set(
+    [...top.matchAll(/(?:^|,)\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\s*:/g)].map(
+      (m) => m[1] ?? m[2] ?? m[3],
+    ),
+  );
+}
+
+async function get(url) {
+  const res = await fetch(url, {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`responded ${res.status}`);
+  return res.json();
+}
+
+if (!endpoint) {
+  skip("PUBLIC_FEE_SCHEDULE_URL is not set (pass a URL as an argument to run it by hand)");
+}
+
+const source = readFileSync(LABELS, "utf8");
+const knownCharges = objectKeys(source, "feeLabels");
+const knownAreas = objectKeys(source, "serviceAreaNames");
+
+let index;
+try {
+  index = await get(endpoint);
+} catch (e) {
+  skip(`getFeeSchedule did not answer (${e.message})`);
+}
+
+// Every area, not just the default one: charge ids are per-area subcollections,
+// so checking one area checks one area (#56's second sub-question). The picker
+// offers all of them, so the site has to be able to name all of them.
+const areas = Array.isArray(index.areas) && index.areas.length ? index.areas : [index.area];
+const charges = new Map(); // id -> { description, areas: [] }
+const unreachable = [];
+
+for (const area of areas) {
+  let schedule = area.id === index.area?.id ? index : null;
+  if (!schedule) {
+    const url = new URL(endpoint);
+    url.searchParams.set("area", area.id);
+    try {
+      schedule = await get(url);
+    } catch (e) {
+      unreachable.push(`${area.id} (${e.message})`);
+      continue;
+    }
+  }
+  for (const c of schedule.appCharges ?? []) {
+    if (!charges.has(c.id)) charges.set(c.id, { description: c.description, areas: [] });
+    charges.get(c.id).areas.push(area.id);
+  }
+}
+
+const errors = [];
+const missingCharges = [];
+
+for (const [id, { description, areas: seenIn }] of charges) {
+  if (knownCharges.has(id)) continue;
+  missingCharges.push(id);
+  errors.push(
+    `charge id "${id}" is published in ${seenIn.join(", ")} and ${LABELS} does not cover it\n` +
+      `      the endpoint calls it "${description}", which is what /es/fees would print — in English\n` +
+      `      and because an unclassified charge lands on neither side of the ledger, /fees withholds\n` +
+      `      its example entirely until this is fixed`,
+  );
+}
+
+for (const area of areas) {
+  if (knownAreas.has(area.id)) continue;
+  errors.push(
+    `service area "${area.id}" is offered by the picker and ${LABELS} does not cover it\n` +
+      `      both languages would fall back to the humanised identifier`,
+  );
+}
+
+const stale = [...knownCharges].filter((id) => !charges.has(id));
+const scope =
+  `${charges.size} charge id${charges.size === 1 ? "" : "s"} across ` +
+  `${areas.length - unreachable.length}/${areas.length} area${areas.length === 1 ? "" : "s"}`;
+
+if (errors.length) {
+  console.error(`✗ fee labels (${scope})`);
+  for (const e of errors) console.error(`  ${e}`);
+  console.error(`\n  Both maps are in ${LABELS}.`);
+  if (missingCharges.length) {
+    console.error(`  A charge needs an EN and an ES label, a "family" and a "payer". Neither family`);
+    console.error(`  nor payer is a database field, so both are editorial decisions a human has to`);
+    console.error(`  make: getting them wrong states something false about YeRide's economics on`);
+    console.error(`  the page that exists to be trusted about them (copy-map §2.3).`);
+  }
+  console.error(`  An area needs a display name in both languages — it is brand copy, not data (#47).`);
+  console.error(`  Endpoint: ${endpoint}`);
+  process.exit(1);
+}
+
+console.log(`✓ fee labels (${scope})`);
+for (const u of unreachable) console.log(`  area not checked: ${u}`);
+// Not a failure: an unused label renders nothing, and prod and stage legitimately
+// publish different areas, so the same source would fight itself between them.
+for (const id of stale) console.log(`  unused label: "${id}" — no area publishes it any more`);

--- a/src/i18n/feeLabels.ts
+++ b/src/i18n/feeLabels.ts
@@ -10,12 +10,11 @@
 // so an id this map doesn't cover is never guessed into a family (see /fees).
 //
 // VERIFIED against production 2026-08-01 (#47) — these are the ids
-// `getFeeSchedule` actually returns, not the names positioning.md guessed.
-// Nothing checks that automatically yet: the check that fails on an id the
-// endpoint returns and this map misses needs the live endpoint, which does not
-// exist (yeride-functions#21), so it is filed as #41's leftover in #56. Until it
-// lands, an id added upstream leaks its English description onto /es/fees and
-// only a human will notice.
+// `getFeeSchedule` actually returns, not the names positioning.md guessed, and
+// `scripts/check-fee-labels.mjs` keeps them verified (#56): it asks the live
+// endpoint, across every service area, and fails the deploy on an id this map
+// misses. It runs daily too, because an id added upstream would otherwise sit
+// unnoticed until the next release.
 //
 // `payer` is "driver" for all four, and that is not a guess: YeRide's charges
 // come out of the driver's side in both payment flows (`yeride-functions
@@ -85,10 +84,11 @@ export const feeLabels: Record<string, ChargeLabel> = {
 // servable stage areas are Spanish-speaking, so that is not hypothetical.
 //
 // The cost of keeping it here is that a new area needs a web deploy to launch
-// with a real name. #56 makes that visible instead of silent: it fails the
-// build on an area id this map doesn't cover, the same treatment it gives an
-// uncovered charge id. Until it lands, an uncovered area falls back to its
-// humanised identifier ("Us Mi Detroit") in both languages.
+// with a real name. `scripts/check-fee-labels.mjs` makes that visible instead of
+// silent (#56): it fails the deploy on an area id this map doesn't cover, the
+// same treatment it gives an uncovered charge id. Without it an uncovered area
+// falls back to its humanised identifier ("Us Mi Detroit") in both languages —
+// which is what stage's two other areas do today.
 export const serviceAreaNames: Record<string, Record<Lang, string>> = {
   "us-fl-south-florida": { en: "South Florida", es: "Sur de la Florida" },
 };


### PR DESCRIPTION
Closes #56.

`scripts/check-fee-labels.mjs` asks `getFeeSchedule` what it is publishing right now and fails if `src/i18n/feeLabels.ts` cannot name it — a charge id, or a service area the picker offers. #41 filed this and could not build it; the endpoint now exists ([yeride-functions#21](https://github.com/yeapptech/yeride-functions/issues/21)), so it can.

### The three sub-questions the ticket left open

**Where does it run?** Not in `npm run checks`. A network call there would make every local build and every PR depend on a third party being up, which is the opposite of the dependency-free rule the other two gates follow. It runs

- **on deploy** (`deploy-all.yml`, before the build), where `PUBLIC_FEE_SCHEDULE_URL` already exists;
- **daily** (`fee-label-drift.yml`), because drift does not arrive with a deploy — someone files a charge or opens a service area in the admin console, and this site can go weeks without a push. The scheduled run opens an issue (or comments on the open one) and goes red.

It **fails on drift and skips when it cannot ask.** An id the site cannot name is a real defect this repo can fix, and it blocks the deploy. An endpoint that did not answer is not — blocking an unrelated content fix on someone else's uptime is the wrong trade, and a schedule the page cannot fetch already renders `/fees`' designed error state rather than a wrong number. A skip prints a `SKIPPED` line saying nothing was checked.

**Which service areas?** All of them. Charge ids are per-area subcollections, so checking one area checks one area. The check reads the `areas` list, fetches each `?area=<id>`, and unions the ids. Stage proves this is not hypothetical: it publishes three areas, two of which the site cannot name.

**What about `family` and `payer`?** The check can only say a human must classify it, and it says exactly that — neither is a database field, and getting either wrong states something false about YeRide's economics on the page that exists to be trusted about them.

### Also

- An uncovered **area** id fails too, per #47's extension — an area name is bilingual brand copy, so a miss falls back to a humanised slug in both languages.
- A **stale** label (covered here, published by nobody) is a notice, not a failure: it renders nothing, and prod and stage legitimately publish different areas.
- The failure message names the second consequence, which is easy to miss — an unclassified charge lands on neither side of the ledger, so `/fees` withholds its example **entirely**.
- Comments in `feeLabels.ts` saying nothing checks this yet are retired, and `CLAUDE.md` documents the gate that lives outside `npm run build`.

### Verified

| case | result |
|---|---|
| production endpoint | ✓ passes — 4 charge ids across 1/1 area |
| stage endpoint | ✗ fails on `us-mi-detroit` and `ve-ta-san-cristobal` |
| stub publishing `winterSurcharge` in one area only | ✗ fails, naming the area it appeared in |
| unreachable endpoint / unset URL | skips, exit 0 |
| `npm run build` | green (route parity, copy gate, `astro check`, build) |
| both drift branches (create + comment), `gh` stubbed | issue body renders correctly, run exits 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)