### PR TITLE
The copy gate, run over the built site (wayfinder #57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,17 +11,18 @@ YeRide website — a static marketing, pre-registration, and fare-estimate site 
 ```bash
 npm run dev        # Dev server at http://localhost:4321
 npm run checks     # Route parity + copy gate (both fast, no deps)
-npm run build      # npm run checks + astro check (type-check) + astro build → dist/
+npm run build      # npm run checks + astro check + astro build → dist/ + dist copy gate
 npm run preview    # Preview production build locally
 ```
 
-No test runner and no linter are configured. `npm run build` is the only automated verification gate. It runs three things in order, and any one of them fails the build:
+No test runner and no linter are configured. `npm run build` is the only automated verification gate. It runs four things in order, and any one of them fails the build:
 
 1. **`scripts/check-route-parity.mjs`** — every route under `src/pages` has its `/es/` twin. `404` and `redirect` are exempt by name (single file, language switched client-side). Routes whose twin is not built yet sit in a `PENDING` map naming the ticket that retires them; an entry whose twin now exists fails, so the list cannot go stale.
-2. **`scripts/check-copy-gate.mjs`** — gated and never-claimed strings (`docs/copy-map.md` §5, on the unmerged `copy-map/en-es` branch) must not reach the site. Scans `src/` and `public/`. See the script header for the escape hatch and, more importantly, for what the check *cannot* catch — it is a line matcher over source text, so a phrase broken across a tag, an entity or a newline slips it, as does copy arriving from the fee-schedule endpoint at runtime.
+2. **`scripts/check-copy-gate.mjs`** — gated and never-claimed strings (`docs/copy-map.md` §5, on the unmerged `copy-map/en-es` branch) must not reach the site. Scans `src/` and `public/` and fails on a Greek or Cyrillic letter, which in EN/ES copy is a homoglyph hiding a gated word. It is a line matcher over **source** text, so a phrase broken across a tag, an entity or a newline slips it — that is item 4's job. Its value is the file-and-line failure at the point of authorship, and it owns the per-line `copy-gate-allow` escape hatch; see the script header.
 3. **`astro check`** — a type error fails the build.
+4. **`scripts/check-dist-copy-gate.mjs`** — the same §5 list (both gates import `scripts/copy-gate-patterns.mjs`; one list, never two) run over `dist/` **after** `astro build`, with character references decoded, invisible characters removed, JS escapes resolved, whitespace collapsed and three views of each HTML file matched. This is the layer that measures the actual promise — a forbidden claim must not reach the shipped site — and it is not optional for `/fees`, whose copy is rendered client-side and so exists only in the JS bundle, never in the built HTML. Source pragmas are stripped by the build and cannot be seen from here, so it carries its **own** allowlist keyed to the hash-free path, the matched text and an exact count; an entry that stops matching, or matches a different number of times, fails. Run it alone with `npm run check:dist` (needs a `dist/`).
 
-`.github/workflows/checks.yml` runs items 1–2 on every pull request; `deploy-all.yml` runs the full chain on `main` and gates deployment on it.
+`.github/workflows/checks.yml` runs items 1–2 on every pull request — it is dependency-free by design, and items 3–4 need `npm ci` against the private registry. `deploy-all.yml` runs the full chain on `main` and gates deployment on it, so item 4 is a pre-deploy backstop rather than a PR-time one.
 
 One further gate runs **outside `npm run build`**, because it needs the network:
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -287,9 +287,14 @@ insurance. Copy-map §5 gates that word on #48 and the gate is a line matcher, s
 tell that denial from a claim — hence the pragmas, which print on every build. When #48
 lands the statements become *false* and must be rewritten, not merely un-pragma'd.
 
-Those pragmas are stripped by the build, so the same four sentences are blessed a **second**
-time in `scripts/check-dist-copy-gate.mjs`'s `ALLOWED` list, keyed to the built pages
-(#57). Both lists are self-cleaning, so editing a legal sentence that contains *insurance*,
+Those pragmas are stripped by the build, so the same sentences are blessed a **second** time
+in `scripts/check-dist-copy-gate.mjs`'s `ALLOWED` list, keyed to the built pages (#57).
+Five entries cover the four pragmas, because §5's `/\b(seguros?|aseguranza|p[óo]liza)\b/`
+matches **twice** in *"el número de póliza de seguro del vehículo"* — two words, one
+sentence. Note that only two of the four are denials; the other two name the vehicle
+insurance policy number as a field the app collects.
+
+Both lists are self-cleaning, so editing a legal sentence that contains *insurance*,
 *seguro* or *póliza* — even to add a second one — fails the build until both are updated.
 That cost is the point: adding one is a decision.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -287,6 +287,12 @@ insurance. Copy-map §5 gates that word on #48 and the gate is a line matcher, s
 tell that denial from a claim — hence the pragmas, which print on every build. When #48
 lands the statements become *false* and must be rewritten, not merely un-pragma'd.
 
+Those pragmas are stripped by the build, so the same four sentences are blessed a **second**
+time in `scripts/check-dist-copy-gate.mjs`'s `ALLOWED` list, keyed to the built pages
+(#57). Both lists are self-cleaning, so editing a legal sentence that contains *insurance*,
+*seguro* or *póliza* — even to add a second one — fails the build until both are updated.
+That cost is the point: adding one is a decision.
+
 **Four refusals it enforces.** Read #38 before relaxing any of them:
 
 1. **It shows the fare and nothing else about money.** `estimateFares` also returns

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "checks": "node scripts/check-route-parity.mjs && node scripts/check-copy-gate.mjs",
     "check:fee-labels": "node scripts/check-fee-labels.mjs",
-    "build": "npm run checks && astro check && astro build",
+    "check:dist": "node scripts/check-dist-copy-gate.mjs",
+    "build": "npm run checks && astro check && astro build && npm run check:dist",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/scripts/check-copy-gate.mjs
+++ b/scripts/check-copy-gate.mjs
@@ -43,6 +43,43 @@ const TICKET = /#\d+(?!\w)/;
 const IN_COMMENT = /(\/\/|\/\*|<!--|^[ \t]*\*)/;
 const COMMENT_ONLY_LINE = /^[ \t]*(\{?[ \t]*\/\*|\/\/|\*)/;
 
+// Homoglyphs, answering #57's "is folding honest?" with no. A Cyrillic "\u0435"
+// in "ch\u0435apest" defeats every pattern above, and folding confusables back to
+// ASCII needs a table whose wrong entries would invent failures in Spanish copy.
+// The confusable is itself the defect, so it is caught rather than folded — and
+// caught HERE, not over dist/, because src/ and public/ are wholly authored in
+// this repo. A vendored bundle may legitimately carry other scripts; a YeRide
+// page in English or Spanish never does.
+//
+// Curated, not whole blocks. An earlier revision took the Greek block entire and
+// failed on "\u0394/\u0394t" and "\u03c0" in a comment — legitimate maths, no
+// resemblance to a Latin letter. Only the letters that can PASS FOR Latin are
+// listed, so:
+//   - Cyrillic entire: no Cyrillic letter belongs in EN or ES copy at all.
+//   - Greek: the Latin lookalikes only. \u0394, \u03c0, \u03bc, \u03bb and \u03a9
+//     are left alone.
+//   - Cherokee, fullwidth Latin, Mathematical Alphanumeric Symbols, Roman-numeral
+//     forms, small-capital phonetic letters, and the letterlike \u2126/\u212a/\u212b
+//     — each of which renders as something a reader takes for an ASCII letter.
+// Accented Latin is untouched throughout: \u00e1, \u00e9, \u00f1 and \u00fc are Latin.
+//
+// Suppressible by the same copy-gate-allow pragma as any other hit, because a
+// legitimate exception is possible and an unsuppressable failure is not a gate,
+// it is a wall.
+const CONFUSABLE = new RegExp(
+  "[" +
+    "\\u0400-\\u04FF" + // Cyrillic
+    "\\u0391\\u0392\\u0395\\u0396\\u0397\\u0399\\u039A\\u039C\\u039D\\u039F\\u03A1\\u03A4\\u03A5\\u03A7" + // Greek capitals shaped like Latin
+    "\\u03B1\\u03B9\\u03BA\\u03BD\\u03BF\\u03C1\\u03C3\\u03C5\\u03C7" + // Greek lowercase shaped like Latin
+    "\\u13A0-\\u13FF" + // Cherokee
+    "\\u1D00-\\u1D25" + // small-capital phonetic letters
+    "\\u2126\\u212A\\u212B" + // ohm, kelvin, angstrom
+    "\\u2160-\\u217F" + // Roman numeral forms
+    "\\uFF21-\\uFF3A\\uFF41-\\uFF5A" + // fullwidth Latin
+    "]|[\\u{1D400}-\\u{1D7FF}]", // Mathematical Alphanumeric Symbols
+  "u",
+);
+
 // Blank comments out, keeping every newline so line numbers still line up.
 //
 // Only LINE-LEADING comment openers are stripped. A "//" or "/*" mid-line is far
@@ -96,55 +133,48 @@ for (const file of files) {
     });
   });
 
+  // A hit on line `here` is covered by a pragma on that same line, or by a
+  // comment-only pragma on the line directly above it.
+  const judge = (here, hit, why) => {
+    const pragma =
+      pragmas.find((p) => p.file === file && p.line === here) ??
+      pragmas.find((p) => p.file === file && p.line === here - 1 && p.coversNext);
+    const where = `${file}:${here}`;
+
+    if (!pragma) {
+      errors.push(`${where}  ${hit} — ${why}`);
+    } else if (!TICKET.test(pragma.reason)) {
+      errors.push(`${where}  copy-gate-allow must name the ticket that retires it, e.g. "#48"`);
+      pragma.used = true;
+    } else {
+      pragma.used = true;
+      allowed.push(`${where}  ${hit} — ${pragma.reason}`);
+    }
+  };
+
   code.forEach((line, i) => {
     for (const { re, why } of PATTERNS) {
       const hit = line.match(re);
-      if (!hit) continue;
-
-      const here = i + 1;
-      const pragma =
-        pragmas.find((p) => p.file === file && p.line === here) ??
-        pragmas.find((p) => p.file === file && p.line === here - 1 && p.coversNext);
-      const where = `${file}:${here}`;
-
-      if (!pragma) {
-        errors.push(`${where}  "${hit[0]}" — ${why}`);
-      } else if (!TICKET.test(pragma.reason)) {
-        errors.push(`${where}  copy-gate-allow must name the ticket that retires it, e.g. "#48"`);
-        pragma.used = true;
-      } else {
-        pragma.used = true;
-        allowed.push(`${where}  "${hit[0]}" — ${pragma.reason}`);
-      }
+      if (hit) judge(i + 1, `"${hit[0]}"`, why);
     }
+  });
+
+  // Homoglyphs are read from the RAW line, comments included: an HTML comment in
+  // an .astro file ships, and a confusable is worth catching wherever it is.
+  raw.forEach((line, i) => {
+    const hit = line.match(CONFUSABLE);
+    if (!hit) return;
+    const point = `U+${hit[0].codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`;
+    judge(
+      i + 1,
+      `"${hit[0]}" (${point})`,
+      "not a Latin letter, but shaped like one — a homoglyph hides a gated word from every pattern above",
+    );
   });
 }
 
 for (const p of pragmas.filter((p) => !p.used)) {
   errors.push(`${p.file}:${p.line}  copy-gate-allow matches nothing any more — delete it`);
-}
-
-// Homoglyphs, answering #57's "is folding honest?" with no. A Cyrillic "е" in
-// "chеapest" defeats every pattern above, and folding confusables back to ASCII
-// needs a table whose wrong entries would invent failures in Spanish copy. The
-// confusable is itself the defect, so it is caught rather than folded — and it is
-// caught HERE, not over dist/, because src/ and public/ are wholly authored in
-// this repo. A vendored bundle may legitimately carry other scripts; a YeRide
-// page in English or Spanish never does. Accented Latin is untouched: á, é, ñ and
-// ü are Latin, and this looks only at the Greek and Cyrillic blocks.
-const CONFUSABLE_SCRIPT = /[Ͱ-ϿЀ-ӿ]/;
-for (const file of files) {
-  readFileSync(file, "utf8")
-    .split(/\r?\n/)
-    .forEach((line, i) => {
-      const hit = line.match(CONFUSABLE_SCRIPT);
-      if (!hit) return;
-      const point = `U+${hit[0].codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`;
-      errors.push(
-        `${file}:${i + 1}  "${hit[0]}" (${point}) is a Greek or Cyrillic letter in EN/ES copy — ` +
-          `almost certainly a homoglyph that hides a gated word from this gate`,
-      );
-    });
 }
 
 // Copy-map §3.4 suspends the family-2 heading, lead and insurance note "until

--- a/scripts/check-copy-gate.mjs
+++ b/scripts/check-copy-gate.mjs
@@ -15,20 +15,21 @@
 // WHAT THIS CANNOT DO — read before trusting it (adversarial review, 2026-08-02):
 // it is a line matcher over source text, so it holds against careless mistakes
 // and not against evasion. A phrase broken across a tag, an HTML entity or a
-// newline slips it ("at&nbsp;cost", "no\n surprises", "$" + "9"); so does copy
-// that arrives from the fee-schedule endpoint at runtime, and so does anything
-// in a file type this does not scan. The gate that would subsume those runs the
-// same pattern list over dist/ after the build, with entities and whitespace
-// normalised — filed as its own ticket, not done here.
+// newline slips it ("at&nbsp;cost", "no\n surprises"); so does copy that arrives
+// from the fee-schedule endpoint at runtime, and so does anything in a file type
+// this does not scan. Most of that is now covered by the second layer,
+// scripts/check-dist-copy-gate.mjs (#57), which runs this same pattern list over
+// the built output. This gate is still the one worth keeping: it fails at the
+// point of authorship with a file and a line number, it runs on every PR without
+// a build, and it is where the allowlist bookkeeping lives.
 //
 // Three §5 rules are judgement, not regex, and are NOT checked here — they stay
-// human review at copy time:
-//   - copy claiming a visible per-trip fee breakdown in the app
-//   - invented per-trip price or earnings comparisons against Uber or Lyft
-//   - safety claims beyond Fla. Stat. § 627.748
+// human review at copy time. The list lives with the patterns.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+
+import { PATTERNS } from "./copy-gate-patterns.mjs";
 
 // public/ is copied verbatim into dist/, so it ships exactly as written.
 const ROOTS = ["src", "public"];
@@ -41,46 +42,6 @@ const TICKET = /#\d+(?!\w)/;
 // authorise itself, e.g. <p data-note="copy-gate-allow: ... #48">.
 const IN_COMMENT = /(\/\/|\/\*|<!--|^[ \t]*\*)/;
 const COMMENT_ONLY_LINE = /^[ \t]*(\{?[ \t]*\/\*|\/\/|\*)/;
-
-const PATTERNS = [
-  // Gated until positioning obligations 1–3 all ship (driver pillar 2).
-  { re: /see the math/i, why: "gated: driver pillar 2, obligations 1–3" },
-  { re: /cuentas claras/i, why: "gated: driver pillar 2, obligations 1–3" },
-
-  // Gated until YeRide actually has insurance coverage (#48). There is no
-  // pass-through family today: insurance does not exist and card processing is
-  // Stripe billing the driver's own connected account, not YeRide forwarding it.
-  { re: /\bat[- ]cost\b/i, why: "gated on #48: nothing is passed through at cost" },
-  { re: /\bal costo\b/i, why: "gated on #48: nothing is passed through at cost" },
-  // The separator is required, as §5 writes it. The one-word "passthrough" is
-  // only ever an identifier here (ChargeFamily, the family filter), never a claim.
-  { re: /\bpass(es|ed|ing)?[- ]through\b/i, why: "gated on #48: the pass-through family has no members" },
-  { re: /\b(zero|without) markup\b/i, why: "gated on #48: the pass-through family has no members" },
-  { re: /\bsin (recargo|margen)\b/i, why: "gated on #48: the pass-through family has no members" },
-  // The same claim without any of the words above — §3.4's suspended family-2
-  // lead reads "Costs YeRide forwards without touching." / "…traslada sin tocar."
-  { re: /\bforwards?\b[^.]{0,30}\bwithout touching\b/i, why: "gated on #48: pass-through claim without the words" },
-  { re: /\btraslada\b[^.]{0,30}\bsin tocar\b/i, why: "gated on #48: pass-through claim without the words" },
-  { re: /\binsurance\b/i, why: "gated on #48: YeRide carries no coverage" },
-  { re: /\b(seguros?|aseguranza|p[óo]liza)\b/i, why: "gated on #48: YeRide carries no coverage" },
-  { re: /\bcoverage\b/i, why: "gated on #48: YeRide carries no coverage" },
-  { re: /\bcobertura\b/i, why: "gated on #48: YeRide carries no coverage" },
-
-  // Never claimed, gate or no gate.
-  { re: /\blocked\b/i, why: "never claimed: fares are metered, not locked" },
-  { re: /\bupfront (price|pricing)\b/i, why: "never claimed: fares are metered, not locked" },
-  { re: /\bprecio (fijo|cerrado|garantizado)\b/i, why: "never claimed: fares are metered, not locked" },
-  { re: /\bno surprises\b/i, why: "never claimed: fares are metered, not locked" },
-  { re: /\bsin sorpresas\b/i, why: "never claimed: fares are metered, not locked" },
-  { re: /\bno surge\b(?![ \t]+today)/i, why: 'never claimed: only "no surge today" is permitted (§3.4)' },
-  { re: /\bnunca\b[^.]{0,20}\brecargo\b/i, why: 'never claimed: only "no surge today" is permitted (§3.4)' },
-  { re: /\bcheape(st|r)\b/i, why: "never claimed: no price-leadership claim" },
-  { re: /\blowest (fees|fares|price)\b/i, why: "never claimed: no price-leadership claim" },
-  { re: /\bm[áa]s barat[oa]s?\b/i, why: "never claimed: no price-leadership claim" },
-  { re: /\bm[áa]s econ[óo]mico\b/i, why: "never claimed: no price-leadership claim" },
-  { re: /\$[ \t]?\d/, why: "never claimed: no hard-coded money — every figure is fetched live" },
-  { re: /\b\d[\d,.]*[ \t]*(dollars|USD)\b/i, why: "never claimed: no hard-coded money — every figure is fetched live" },
-];
 
 // Blank comments out, keeping every newline so line numbers still line up.
 //
@@ -161,6 +122,29 @@ for (const file of files) {
 
 for (const p of pragmas.filter((p) => !p.used)) {
   errors.push(`${p.file}:${p.line}  copy-gate-allow matches nothing any more — delete it`);
+}
+
+// Homoglyphs, answering #57's "is folding honest?" with no. A Cyrillic "е" in
+// "chеapest" defeats every pattern above, and folding confusables back to ASCII
+// needs a table whose wrong entries would invent failures in Spanish copy. The
+// confusable is itself the defect, so it is caught rather than folded — and it is
+// caught HERE, not over dist/, because src/ and public/ are wholly authored in
+// this repo. A vendored bundle may legitimately carry other scripts; a YeRide
+// page in English or Spanish never does. Accented Latin is untouched: á, é, ñ and
+// ü are Latin, and this looks only at the Greek and Cyrillic blocks.
+const CONFUSABLE_SCRIPT = /[Ͱ-ϿЀ-ӿ]/;
+for (const file of files) {
+  readFileSync(file, "utf8")
+    .split(/\r?\n/)
+    .forEach((line, i) => {
+      const hit = line.match(CONFUSABLE_SCRIPT);
+      if (!hit) return;
+      const point = `U+${hit[0].codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`;
+      errors.push(
+        `${file}:${i + 1}  "${hit[0]}" (${point}) is a Greek or Cyrillic letter in EN/ES copy — ` +
+          `almost certainly a homoglyph that hides a gated word from this gate`,
+      );
+    });
 }
 
 // Copy-map §3.4 suspends the family-2 heading, lead and insurance note "until

--- a/scripts/check-dist-copy-gate.mjs
+++ b/scripts/check-dist-copy-gate.mjs
@@ -1,0 +1,311 @@
+// Copy gate, second layer — the same §5 pattern list, run over dist/ after the
+// build. Wayfinder #57.
+//
+// WHY A SECOND GATE. check-copy-gate.mjs matches lines of source text, so it is
+// blind to everything the build does to that text: a phrase broken across a tag,
+// an HTML entity or a newline slips it, and ordinary Prettier wrapping produces
+// that by accident. This one measures the promise itself — a forbidden claim must
+// not reach the shipped site — by reading what is actually shipped.
+//
+// It does not replace the first gate. The source gate fails at the point of
+// authorship with a file and a line number, runs on every PR without a build or
+// a private registry, and owns the per-line allowlist. Keep both.
+//
+// ---------------------------------------------------------------------------
+// WHAT COUNTS AS "SHIPPED": the bytes, not the pixels.
+//
+// Everything under dist/ is publicly fetchable, so everything under dist/ is
+// scanned — including comments, which are not rendered but are served. That is
+// the same call the source gate makes about HTML comments, for the same reason.
+//
+// Scanning the built HTML alone would have caught almost nothing that matters:
+// /fees renders its charge rows client-side, so its copy exists only in
+// dist/_astro/FeeSchedule.*.js and never appears in dist/fees/index.html.
+//
+// ---------------------------------------------------------------------------
+// NORMALISATION — how much is honest (#57's third sub-question).
+//
+// Applied, because each is exactly what a browser does, and skipping it would
+// let an accident through:
+//   - character references, decoded in ONE left-to-right pass. One pass is the
+//     point: "&amp;#36;" renders as the literal text "&#36;", not "$", and a
+//     second pass would invent a hit the reader never sees.
+//   - invisible characters (zero-width space/joiner, soft hyphen, BOM) removed —
+//     they exist only to split a word without showing it.
+//   - JS \uXXXX / \xXX / \u{...} escapes decoded in script and style bundles.
+//   - whitespace collapsed to single spaces, so a newline inside a phrase — the
+//     accidental case — reads as the space it renders as.
+//
+// Markup is handled by scanning THREE views of each HTML file, because no single
+// one of them is honest on its own:
+//   - tags left alone: the plain reading.
+//   - tags removed to nothing: catches "Insur<span>ance</span>". It cannot
+//     fabricate a multi-word phrase, because removing a tag removes the gap
+//     rather than creating one — "<li>zero</li><li>markup</li>" becomes
+//     "zeromarkup", which matches nothing.
+//   - tags replaced by a space: catches a phrase split across two elements.
+//     This is the one that CAN fabricate — "<td>no</td><td>surprises</td>" reads
+//     as two cells and matches "no surprises" — so the hit names the view that
+//     produced it, and a fabricated one is blessed once in ALLOWED below.
+// A hit is counted once per matched string, at the highest count any view saw,
+// so the three views cannot inflate each other.
+//
+// NOT applied: homoglyph folding. Folding needs a confusables table, and a wrong
+// entry in it invents failures in Spanish copy, which is full of legitimate
+// non-ASCII. The Cyrillic "е" in "chеapest" is instead caught where it is
+// introduced — check-copy-gate.mjs fails on a Cyrillic or Greek letter in source,
+// which is unambiguous there because no vendored code is in scope.
+//
+// ---------------------------------------------------------------------------
+// WHAT IT STILL CANNOT DO:
+//   - copy assembled at runtime from fragments — ["lowest","fees"].join(" ") —
+//     is invisible to any static check. Server-side assembly IS caught, because
+//     the result is in the built HTML; client-side assembly is not.
+//   - copy that arrives from getFeeSchedule at runtime is in neither the source
+//     nor the build. That residual belongs to #56, which asks the live endpoint
+//     what it publishes and fails the deploy on a charge id this site cannot name
+//     — an unnamed id being exactly the case where FeeSchedule.astro falls back
+//     to printing the backend's own description verbatim.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { PATTERNS } from "./copy-gate-patterns.mjs";
+
+const ROOT = "dist";
+const SCAN_EXT = /\.(html|js|mjs|json|svg|css|txt|xml|webmanifest)$/;
+const MARKUP_EXT = /\.(html|svg|xml)$/;
+const SCRIPT_EXT = /\.(js|mjs|json|css)$/;
+
+// Rollup/Vite stamp a content hash into every emitted asset, so the filename
+// changes whenever the file does. The allowlist below is keyed to the name with
+// that segment removed, which is the part that is stable across builds.
+const CONTENT_HASH = /\.[A-Za-z0-9_-]{8,}(?=\.[A-Za-z0-9]+$)/;
+
+// ---------------------------------------------------------------------------
+// The allowlist (#57's first sub-question: the source pragmas are stripped from
+// the build, so they cannot be seen from here and this needs its own).
+//
+// Every entry is a string a human has looked at and blessed. Keyed by the
+// hash-free path, the matched text, and how many times it may appear — an entry
+// that stops matching, or matches a different number of times, FAILS, exactly as
+// a stale copy-gate-allow pragma does. That is what stops this list going quiet:
+// re-blessing is a decision, and adding one more "insurance" to a legal page
+// should cost one.
+//
+// `why` must name an issue — the same discipline as the source pragma — or say
+// `vendored:` and name the package, for a file this repo does not author and
+// cannot edit. There is no third kind of reason.
+const ALLOWED = [
+  // §3.4's pass-through family is suspended: no charge is filed into the family,
+  // so none of this renders. It is bundled rather than absent, which is a
+  // deliberate trade — deleting the strings would also delete the source pragmas,
+  // and with them the check in check-copy-gate.mjs that fails the build the
+  // moment a charge IS filed into "passthrough". A silent empty panel is worse
+  // than dormant copy. These retire together, with #48.
+  ...[
+    "at cost",
+    "al costo",
+    "passed through",
+    "zero markup",
+    "sin recargo",
+    "forwards without touching",
+    "traslada sin tocar",
+    "insurance",
+    "coverage",
+    "cobertura",
+  ].map((text) => ({
+    file: "_astro/FeeSchedule.astro_astro_type_script_index_0_lang.js",
+    text,
+    count: 1,
+    why: "§3.4 pass-through family suspended — bundled but unreachable, no charge carries the family (#48)",
+  })),
+
+  // The legal pages (#44) DENY that YeRide has insurance. §5 cannot tell a denial
+  // from a claim, and the denial is the honest thing to publish, so it ships.
+  // When #48 lands these sentences become false and must be rewritten — which is
+  // why the entries name it rather than being deleted.
+  { file: "privacy-policy/index.html", text: "insurance", count: 1, why: "factual: a field the app collects (the vehicle's policy number), not a claim YeRide carries any — rewrite when #48 lands" },
+  { file: "es/privacy-policy/index.html", text: "póliza", count: 1, why: "factual: a field the app collects, not a claim YeRide carries any — rewrite when #48 lands" },
+  { file: "es/privacy-policy/index.html", text: "seguro", count: 1, why: "part of \"póliza de seguro\" — the same collected field — rewrite when #48 lands" },
+  { file: "terms/index.html", text: "insurance", count: 1, why: "the denial the gate exists to protect — YeRide has none and says so; rewrite when #48 lands" },
+  { file: "es/terms/index.html", text: "seguro", count: 1, why: "the denial the gate exists to protect — YeRide has none and says so; rewrite when #48 lands" },
+
+  // An XML comment inside the brand lockup, describing why the typeface is fixed:
+  // "Typeface locked by the brand-typography decision (issue #8)". Not copy, not
+  // rendered, and not editable here — brand assets change in the brand repo.
+  { file: "_astro/yeride-lockup.svg", text: "locked", count: 1, why: "vendored: @yeapptech/yeride-brand — an XML comment in the lockup asset, not copy" },
+];
+
+const ISSUE_OR_VENDOR = /#\d+(?!\w)|^vendored:/;
+
+// ---------------------------------------------------------------------------
+
+const REFERENCE = /&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]*);/gi;
+// The named references Astro emits, plus the ones that would be used to split or
+// disguise a word. A reference outside this table is left as written, which is
+// the safe direction: it can hide a claim from this gate, but it cannot invent
+// one — and anything authored in this repo is seen by the source gate first.
+const NAMED = {
+  amp: "&", lt: "<", gt: ">", quot: '"', apos: "'",
+  nbsp: " ", ensp: " ", emsp: " ", thinsp: " ", hairsp: " ",
+  shy: "", zwnj: "", zwj: "", lrm: "", rlm: "",
+  mdash: "—", ndash: "–", hellip: "…", middot: "·",
+  lsquo: "‘", rsquo: "’", ldquo: "“", rdquo: "”",
+  dollar: "$", cent: "¢", pound: "£", euro: "€", yen: "¥",
+  copy: "©", reg: "®", trade: "™", deg: "°", sect: "§", para: "¶",
+};
+
+// Written as escapes, not as the characters themselves: these are invisible, so
+// a literal class here is unreviewable and one lost byte in an editor would
+// silently narrow the gate. Soft hyphen, the zero-width/bidi block, word joiner,
+// BOM.
+const INVISIBLE = /[­​-‏⁠﻿]/g;
+
+const cp = (n) => (n >= 0 && n <= 0x10ffff ? String.fromCodePoint(n) : "");
+
+/** One left-to-right pass, exactly as a browser resolves references. */
+function decodeReferences(s) {
+  return s.replace(REFERENCE, (whole, body) => {
+    if (body[0] === "#") {
+      const n = body[1] === "x" || body[1] === "X"
+        ? parseInt(body.slice(2), 16)
+        : parseInt(body.slice(1), 10);
+      return Number.isNaN(n) ? whole : cp(n);
+    }
+    const named = NAMED[body.toLowerCase()];
+    return named === undefined ? whole : named;
+  });
+}
+
+function decodeScriptEscapes(s) {
+  return s
+    .replace(/\\u\{([0-9a-fA-F]{1,6})\}/g, (_, h) => cp(parseInt(h, 16)))
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => cp(parseInt(h, 16)))
+    .replace(/\\x([0-9a-fA-F]{2})/g, (_, h) => cp(parseInt(h, 16)));
+}
+
+const collapse = (s) => s.replace(INVISIBLE, "").replace(/\s+/g, " ");
+
+/** The views of one file that get matched. See the header. */
+function viewsOf(file, raw) {
+  if (MARKUP_EXT.test(file)) {
+    const decoded = decodeReferences(raw);
+    return [
+      { name: "as-shipped", text: collapse(decoded) },
+      { name: "tags-removed", text: collapse(decoded.replace(/<[^>]*>/g, "")) },
+      { name: "tags-as-space", text: collapse(decoded.replace(/<[^>]*>/g, " ")) },
+    ];
+  }
+  if (SCRIPT_EXT.test(file)) {
+    return [{ name: "as-shipped", text: collapse(decodeScriptEscapes(raw)) }];
+  }
+  return [{ name: "as-shipped", text: collapse(raw) }];
+}
+
+function walk(dir) {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    return statSync(path).isDirectory() ? walk(path) : [path];
+  });
+}
+
+const keyOf = (path) =>
+  path.replace(/^dist[/\\]/, "").replace(/\\/g, "/").replace(CONTENT_HASH, "");
+
+// Extensions that cannot carry readable copy. Everything else that is not
+// scanned gets named in the output: a file type this gate silently ignored would
+// otherwise read as a file type it cleared.
+const BINARY = /\.(png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|eot|pdf|mp4|webm)$/i;
+
+let everything;
+let files;
+try {
+  everything = walk(ROOT);
+  files = everything.filter((p) => SCAN_EXT.test(p));
+} catch {
+  console.error(`✗ dist copy gate — no ${ROOT}/ to scan`);
+  console.error(`  This runs after "astro build". Run "npm run build", not this script alone.`);
+  process.exit(1);
+}
+
+const errors = [];
+const allowed = [];
+const unused = new Set(ALLOWED.keys());
+const unread = new Set(
+  everything
+    .filter((p) => !SCAN_EXT.test(p) && !BINARY.test(p))
+    .map((p) => (/\.[A-Za-z0-9]+$/.exec(p) ?? ["(no extension)"])[0]),
+);
+let scanned = 0;
+
+for (const path of files) {
+  scanned++;
+  const key = keyOf(path);
+  const views = viewsOf(path, readFileSync(path, "utf8"));
+
+  // patternIndex + matched text -> { count, view, why }. The count is the
+  // highest any single view saw, never the sum, so three views of one string
+  // stay one hit.
+  const hits = new Map();
+  for (const view of views) {
+    for (const [index, { re, why }] of PATTERNS.entries()) {
+      const global = new RegExp(re.source, re.flags.includes("g") ? re.flags : `${re.flags}g`);
+      const seen = new Map();
+      for (const m of view.text.matchAll(global)) {
+        const text = m[0].toLowerCase();
+        seen.set(text, (seen.get(text) ?? 0) + 1);
+      }
+      for (const [text, count] of seen) {
+        const id = `${index} ${text}`;
+        const prior = hits.get(id);
+        if (!prior || count > prior.count) hits.set(id, { text, count, view: view.name, why });
+      }
+    }
+  }
+
+  for (const { text, count, view, why } of hits.values()) {
+    const at = ALLOWED.findIndex((a) => a.file === key && a.text.toLowerCase() === text);
+    const where = `${key}  "${text}" ×${count} [${view}]`;
+
+    if (at === -1) {
+      errors.push(`${where} — ${why}`);
+      continue;
+    }
+    unused.delete(at);
+    const entry = ALLOWED[at];
+    if (entry.count !== count) {
+      errors.push(
+        `${where} — allowed ×${entry.count}, found ×${count}. A changed count is a changed claim: ` +
+          `re-read it, then update the entry in scripts/check-dist-copy-gate.mjs`,
+      );
+    } else if (!ISSUE_OR_VENDOR.test(entry.why)) {
+      errors.push(`${where} — the allowlist reason must name an issue, or start with "vendored:"`);
+    } else {
+      allowed.push(`${where} — ${entry.why}`);
+    }
+  }
+}
+
+for (const index of unused) {
+  const { file, text, count } = ALLOWED[index];
+  errors.push(
+    `${file}  "${text}" ×${count} is allowed but no longer appears — delete the entry ` +
+      `from scripts/check-dist-copy-gate.mjs`,
+  );
+}
+
+if (errors.length) {
+  console.error(`✗ dist copy gate (${scanned} files)`);
+  for (const e of errors) console.error(`  ${e}`);
+  console.error(`\n  The list is docs/copy-map.md §5, on the copy-map/en-es branch until it merges:`);
+  console.error(`    git show origin/copy-map/en-es:docs/copy-map.md`);
+  console.error(`  A source pragma cannot reach here — it is stripped by the build. A string that`);
+  console.error(`  has to ship without being a claim is blessed in this script's ALLOWED list,`);
+  console.error(`  keyed to the path above, with a reason naming the issue that retires it.`);
+  process.exit(1);
+}
+
+console.log(`✓ dist copy gate (${scanned} files)`);
+for (const a of allowed) console.log(`  allowed: ${a}`);
+for (const ext of unread) console.log(`  not read: ${ext} — add it to SCAN_EXT if it can carry copy`);

--- a/scripts/check-dist-copy-gate.mjs
+++ b/scripts/check-dist-copy-gate.mjs
@@ -20,41 +20,64 @@
 //
 // Scanning the built HTML alone would have caught almost nothing that matters:
 // /fees renders its charge rows client-side, so its copy exists only in
-// dist/_astro/FeeSchedule.*.js and never appears in dist/fees/index.html.
+// dist/_astro/FeeSchedule.*.js and never appears in dist/fees/index.html. That
+// same fact is why character references are decoded in SCRIPT files too: a
+// bundle that assigns "&#105;nsurance" to innerHTML publishes the word.
 //
 // ---------------------------------------------------------------------------
-// NORMALISATION — how much is honest (#57's third sub-question).
+// HOW IT READS A FILE — several views, one count.
 //
-// Applied, because each is exactly what a browser does, and skipping it would
-// let an accident through:
-//   - character references, decoded in ONE left-to-right pass. One pass is the
+// A claim can hide from any single normalisation, so each file is read through
+// several VIEWS. Every view records, for each character it emits, the offset in
+// the original bytes that character came from. A match is therefore a SPAN of
+// original bytes, not a position in some derived string.
+//
+// That is what makes counting honest. Overlapping spans from different views are
+// ONE occurrence — the same claim seen twice. Disjoint spans are DIFFERENT
+// occurrences, however they were found. An earlier revision of this file took
+// the maximum count across views instead, and an independent review broke it in
+// one line: a claim in an alt attribute (visible only to the untouched view) plus
+// a tag-split claim (visible only to the tag-stripped view) both counted 1, so a
+// single "×1" allowance passed two shipped claims on the one page this gate
+// exists to protect. Spans cannot be fooled that way.
+//
+// The views, and what each is for:
+//   - tags kept          the plain reading; also the only view that sees
+//                        attribute text (alt, title, content), since stripping a
+//                        tag takes its attributes with it.
+//   - tags removed       catches "Insur<span>ance</span>". It cannot fabricate a
+//                        multi-word phrase: removing a tag removes the gap, so
+//                        "<li>zero</li><li>markup</li>" becomes "zeromarkup".
+//   - tags to a space    catches a phrase split across two elements. This is the
+//                        one view that CAN fabricate — "<td>no</td>
+//                        <td>surprises</td>" reads as two cells — so every hit
+//                        names the view that produced it, and a fabricated one is
+//                        blessed once in ALLOWED below.
+//   - unknown references blanked / spaced
+//                        the NAMED table below cannot hold all ~2200 HTML5
+//                        entities. Rather than pretend, anything it does not know
+//                        is ALSO tried as "" and as " ", so "no&NewLine;surprises"
+//                        is caught without needing &NewLine; in the table.
+//   - escapes decoded    \uXXXX, \xXX, \u{...} and CSS's "\69 " form. Applied to
+//                        markup as well as scripts, because an inline <script> in
+//                        a built page is markup by extension and a bundle by
+//                        content.
+//
+// Applied in every view, because each is exactly what a browser does:
+//   - character references decoded in ONE left-to-right pass. One pass is the
 //     point: "&amp;#36;" renders as the literal text "&#36;", not "$", and a
 //     second pass would invent a hit the reader never sees.
 //   - invisible characters (zero-width space/joiner, soft hyphen, BOM) removed —
 //     they exist only to split a word without showing it.
-//   - JS \uXXXX / \xXX / \u{...} escapes decoded in script and style bundles.
 //   - whitespace collapsed to single spaces, so a newline inside a phrase — the
 //     accidental case — reads as the space it renders as.
 //
-// Markup is handled by scanning THREE views of each HTML file, because no single
-// one of them is honest on its own:
-//   - tags left alone: the plain reading.
-//   - tags removed to nothing: catches "Insur<span>ance</span>". It cannot
-//     fabricate a multi-word phrase, because removing a tag removes the gap
-//     rather than creating one — "<li>zero</li><li>markup</li>" becomes
-//     "zeromarkup", which matches nothing.
-//   - tags replaced by a space: catches a phrase split across two elements.
-//     This is the one that CAN fabricate — "<td>no</td><td>surprises</td>" reads
-//     as two cells and matches "no surprises" — so the hit names the view that
-//     produced it, and a fabricated one is blessed once in ALLOWED below.
-// A hit is counted once per matched string, at the highest count any view saw,
-// so the three views cannot inflate each other.
-//
 // NOT applied: homoglyph folding. Folding needs a confusables table, and a wrong
 // entry in it invents failures in Spanish copy, which is full of legitimate
-// non-ASCII. The Cyrillic "е" in "chеapest" is instead caught where it is
-// introduced — check-copy-gate.mjs fails on a Cyrillic or Greek letter in source,
-// which is unambiguous there because no vendored code is in scope.
+// non-ASCII. A confusable is instead caught where it is introduced —
+// check-copy-gate.mjs fails on Cyrillic, Latin-lookalike Greek, fullwidth and
+// mathematical letters in source, which is unambiguous there because no vendored
+// code is in scope.
 //
 // ---------------------------------------------------------------------------
 // WHAT IT STILL CANNOT DO:
@@ -66,20 +89,40 @@
 //     what it publishes and fails the deploy on a charge id this site cannot name
 //     — an unnamed id being exactly the case where FeeSchedule.astro falls back
 //     to printing the backend's own description verbatim.
+//   - a claim rendered from base64, URL-encoding or any other payload this does
+//     not decode. Decoding everything a browser can execute is a losing race; the
+//     source gate is the layer that sees such a string being authored.
+//
+// KNOWN FALSE-POSITIVE SOURCES, both deliberate:
+//   - the "tags to a space" view, as described above.
+//   - §5's /\$[ \t]?\d/ matches a regex backreference like "$1" in a minified
+//     vendor chunk. Nothing in dist/ trips it today, but a dependency bump can.
+//     The pattern is §5's and shared with the source gate, so it is not narrowed
+//     here; the failure is loud and one ALLOWED entry retires it.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import { PATTERNS } from "./copy-gate-patterns.mjs";
 
 const ROOT = "dist";
-const SCAN_EXT = /\.(html|js|mjs|json|svg|css|txt|xml|webmanifest)$/;
-const MARKUP_EXT = /\.(html|svg|xml)$/;
-const SCRIPT_EXT = /\.(js|mjs|json|css)$/;
+// Case-insensitive: a page served as .HTML is still a page. GitHub Pages serves
+// .htm and .xhtml as text/html too.
+const SCAN_EXT = /\.(html?|xhtml|js|mjs|cjs|json|map|svg|css|txt|xml|webmanifest)$/i;
+const MARKUP_EXT = /\.(html?|xhtml|svg|xml)$/i;
+// Extensions that cannot carry readable copy. Everything else that is not
+// scanned gets named in the output, on the failure path as well as the success
+// one: a file type this gate silently ignored would otherwise read as a file type
+// it cleared.
+const BINARY = /\.(png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|eot|pdf|mp4|webm|zip|gz)$/i;
 
-// Rollup/Vite stamp a content hash into every emitted asset, so the filename
-// changes whenever the file does. The allowlist below is keyed to the name with
-// that segment removed, which is the part that is stable across builds.
+// Rollup stamps a content hash into the assets it emits, so the filename changes
+// whenever the file does. The allowlist is keyed to the name with that segment
+// removed. Only files under _astro/ are treated this way — page paths and
+// anything copied verbatim from public/ keep their names, and stripping a
+// dot-segment from those would mangle a legitimate name like
+// "fee.schedule.json" into "fee.json".
+const HASHED_DIR = "_astro/";
 const CONTENT_HASH = /\.[A-Za-z0-9_-]{8,}(?=\.[A-Za-z0-9]+$)/;
 
 // ---------------------------------------------------------------------------
@@ -121,10 +164,12 @@ const ALLOWED = [
     why: "§3.4 pass-through family suspended — bundled but unreachable, no charge carries the family (#48)",
   })),
 
-  // The legal pages (#44) DENY that YeRide has insurance. §5 cannot tell a denial
-  // from a claim, and the denial is the honest thing to publish, so it ships.
-  // When #48 lands these sentences become false and must be rewritten — which is
-  // why the entries name it rather than being deleted.
+  // The legal pages (#44). Two of these sentences DENY that YeRide has
+  // insurance; the other three name the vehicle insurance policy number as a
+  // field the app collects. §5 cannot tell either from a claim, and both are the
+  // honest thing to publish, so they ship. When #48 lands the denials become
+  // false and must be rewritten — which is why the entries name it rather than
+  // being deleted.
   { file: "privacy-policy/index.html", text: "insurance", count: 1, why: "factual: a field the app collects (the vehicle's policy number), not a claim YeRide carries any — rewrite when #48 lands" },
   { file: "es/privacy-policy/index.html", text: "póliza", count: 1, why: "factual: a field the app collects, not a claim YeRide carries any — rewrite when #48 lands" },
   { file: "es/privacy-policy/index.html", text: "seguro", count: 1, why: "part of \"póliza de seguro\" — the same collected field — rewrite when #48 lands" },
@@ -140,15 +185,17 @@ const ALLOWED = [
 const ISSUE_OR_VENDOR = /#\d+(?!\w)|^vendored:/;
 
 // ---------------------------------------------------------------------------
+// Normalisation
 
-const REFERENCE = /&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]*);/gi;
+const REFERENCE = /^&(#[xX][0-9a-fA-F]{1,6}|#\d{1,7}|[a-zA-Z][a-zA-Z0-9]{1,31});/;
+
 // The named references Astro emits, plus the ones that would be used to split or
-// disguise a word. A reference outside this table is left as written, which is
-// the safe direction: it can hide a claim from this gate, but it cannot invent
-// one — and anything authored in this repo is seen by the source gate first.
+// disguise a word. This is NOT the full HTML5 set and does not try to be — the
+// "unknown reference blanked / spaced" views cover whatever is missing.
 const NAMED = {
   amp: "&", lt: "<", gt: ">", quot: '"', apos: "'",
-  nbsp: " ", ensp: " ", emsp: " ", thinsp: " ", hairsp: " ",
+  nbsp: " ", ensp: " ", emsp: " ", thinsp: " ", hairsp: " ", puncsp: " ",
+  newline: "\n", tab: "\t",
   shy: "", zwnj: "", zwj: "", lrm: "", rlm: "",
   mdash: "—", ndash: "–", hellip: "…", middot: "·",
   lsquo: "‘", rsquo: "’", ldquo: "“", rdquo: "”",
@@ -156,124 +203,268 @@ const NAMED = {
   copy: "©", reg: "®", trade: "™", deg: "°", sect: "§", para: "¶",
 };
 
-// Written as escapes, not as the characters themselves: these are invisible, so
-// a literal class here is unreviewable and one lost byte in an editor would
-// silently narrow the gate. Soft hyphen, the zero-width/bidi block, word joiner,
-// BOM.
-const INVISIBLE = /[­​-‏⁠﻿]/g;
+// Written as escapes, not as the characters themselves: these are invisible, so a
+// literal class here would be unreviewable, would make this file read as binary
+// to grep and file(1), and one lost byte in an editor would silently narrow the
+// gate. Soft hyphen, the zero-width/bidi block, word joiner, BOM.
+const INVISIBLE = new Set([
+  "\u00AD", "\u200B", "\u200C", "\u200D", "\u200E", "\u200F", "\u2060", "\uFEFF",
+]);
 
-const cp = (n) => (n >= 0 && n <= 0x10ffff ? String.fromCodePoint(n) : "");
+const cp = (n) => (Number.isFinite(n) && n >= 0 && n <= 0x10ffff ? String.fromCodePoint(n) : "");
 
-/** One left-to-right pass, exactly as a browser resolves references. */
-function decodeReferences(s) {
-  return s.replace(REFERENCE, (whole, body) => {
-    if (body[0] === "#") {
-      const n = body[1] === "x" || body[1] === "X"
-        ? parseInt(body.slice(2), 16)
-        : parseInt(body.slice(1), 10);
-      return Number.isNaN(n) ? whole : cp(n);
+/** The decoded value of one character reference, or null if this table cannot
+ *  resolve it. Numeric references always resolve; named ones may not. */
+function decodeReference(body) {
+  if (body[0] === "#") {
+    const hex = body[1] === "x" || body[1] === "X";
+    const n = parseInt(hex ? body.slice(2) : body.slice(1), hex ? 16 : 10);
+    return Number.isNaN(n) ? null : cp(n);
+  }
+  const named = NAMED[body.toLowerCase()];
+  return named === undefined ? null : named;
+}
+
+/** A JS or CSS escape at `raw[i]`, as [decodedText, consumedLength], or null.
+ *  CSS spells the same idea "\69 " — 1-6 hex digits and an optional trailing
+ *  space that is part of the escape rather than of the text. */
+function decodeEscape(raw, i) {
+  const braced = /^\\u\{([0-9a-fA-F]{1,6})\}/.exec(raw.slice(i, i + 10));
+  if (braced) return [cp(parseInt(braced[1], 16)), braced[0].length];
+
+  const u = /^\\u([0-9a-fA-F]{4})/.exec(raw.slice(i, i + 6));
+  if (u) return [cp(parseInt(u[1], 16)), u[0].length];
+
+  const x = /^\\x([0-9a-fA-F]{2})/.exec(raw.slice(i, i + 4));
+  if (x) return [cp(parseInt(x[1], 16)), x[0].length];
+
+  const css = /^\\([0-9a-fA-F]{1,6})[ \t\n]?/.exec(raw.slice(i, i + 9));
+  if (css) return [cp(parseInt(css[1], 16)), css[0].length];
+
+  return null;
+}
+
+/**
+ * One reading of `raw`.
+ *
+ * Returns { text, map } where map[n] is the offset in `raw` that text[n] came
+ * from, so a match in `text` can be reported as a span of original bytes. Every
+ * view of a file maps back to the same coordinates, which is what lets
+ * overlapping matches from different views be recognised as one occurrence.
+ */
+function view(raw, { tags = "keep", unknownReference = "keep", escapes = false }) {
+  const out = [];
+  const map = [];
+  let pendingSpace = -1;
+
+  const emit = (ch, at) => {
+    if (INVISIBLE.has(ch)) return;
+    if (/\s/.test(ch)) {
+      if (pendingSpace < 0) pendingSpace = at;
+      return;
     }
-    const named = NAMED[body.toLowerCase()];
-    return named === undefined ? whole : named;
-  });
-}
+    if (pendingSpace >= 0) {
+      out.push(" ");
+      map.push(pendingSpace);
+      pendingSpace = -1;
+    }
+    out.push(ch);
+    map.push(at);
+  };
+  const emitAll = (s, at) => {
+    for (const ch of s) emit(ch, at);
+  };
 
-function decodeScriptEscapes(s) {
-  return s
-    .replace(/\\u\{([0-9a-fA-F]{1,6})\}/g, (_, h) => cp(parseInt(h, 16)))
-    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => cp(parseInt(h, 16)))
-    .replace(/\\x([0-9a-fA-F]{2})/g, (_, h) => cp(parseInt(h, 16)));
-}
+  for (let i = 0; i < raw.length; ) {
+    const ch = raw[i];
 
-const collapse = (s) => s.replace(INVISIBLE, "").replace(/\s+/g, " ");
+    if (tags !== "keep" && ch === "<") {
+      const end = raw.indexOf(">", i);
+      if (end !== -1) {
+        if (tags === "space") emit(" ", i);
+        i = end + 1;
+        continue;
+      }
+    }
 
-/** The views of one file that get matched. See the header. */
-function viewsOf(file, raw) {
-  if (MARKUP_EXT.test(file)) {
-    const decoded = decodeReferences(raw);
-    return [
-      { name: "as-shipped", text: collapse(decoded) },
-      { name: "tags-removed", text: collapse(decoded.replace(/<[^>]*>/g, "")) },
-      { name: "tags-as-space", text: collapse(decoded.replace(/<[^>]*>/g, " ")) },
-    ];
+    if (ch === "&") {
+      const hit = REFERENCE.exec(raw.slice(i, i + 36));
+      if (hit) {
+        const decoded = decodeReference(hit[1]);
+        if (decoded !== null) emitAll(decoded, i);
+        else if (unknownReference === "blank") void 0;
+        else if (unknownReference === "space") emit(" ", i);
+        else emitAll(hit[0], i);
+        i += hit[0].length;
+        continue;
+      }
+    }
+
+    if (escapes && ch === "\\") {
+      const hit = decodeEscape(raw, i);
+      if (hit) {
+        emitAll(hit[0], i);
+        i += hit[1];
+        continue;
+      }
+    }
+
+    emit(ch, i);
+    i++;
   }
-  if (SCRIPT_EXT.test(file)) {
-    return [{ name: "as-shipped", text: collapse(decodeScriptEscapes(raw)) }];
-  }
-  return [{ name: "as-shipped", text: collapse(raw) }];
+
+  return { text: out.join(""), map };
 }
+
+/** Every reading of one file. Markup gets the tag treatments; everything else is
+ *  read once plain and once with escapes resolved. Character references are
+ *  decoded everywhere, because a bundle that writes them into innerHTML
+ *  publishes them. */
+function viewsOf(path, raw) {
+  const named = [];
+  const add = (name, opts) => named.push({ name, ...view(raw, opts) });
+
+  if (MARKUP_EXT.test(path)) {
+    add("as-shipped", { tags: "keep" });
+    add("tags-removed", { tags: "drop" });
+    add("tags-as-space", { tags: "space" });
+    add("escapes-decoded", { tags: "keep", escapes: true });
+    add("entities-blanked", { tags: "drop", unknownReference: "blank" });
+    add("entities-spaced", { tags: "space", unknownReference: "space" });
+    return named;
+  }
+
+  add("as-shipped", {});
+  add("escapes-decoded", { escapes: true });
+  add("entities-spaced", { unknownReference: "space" });
+  return named;
+}
+
+// ---------------------------------------------------------------------------
 
 function walk(dir) {
-  return readdirSync(dir).flatMap((entry) => {
-    const path = join(dir, entry);
-    return statSync(path).isDirectory() ? walk(path) : [path];
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    try {
+      // A symlink is resolved rather than trusted; a dangling one is skipped
+      // instead of throwing out of the whole walk.
+      return statSync(path).isDirectory() ? walk(path) : [path];
+    } catch {
+      return [];
+    }
   });
 }
 
-const keyOf = (path) =>
-  path.replace(/^dist[/\\]/, "").replace(/\\/g, "/").replace(CONTENT_HASH, "");
+const keyOf = (path) => {
+  const rel = path.replace(/^dist[/\\]/, "").replace(/\\/g, "/");
+  return rel.startsWith(HASHED_DIR) ? rel.replace(CONTENT_HASH, "") : rel;
+};
 
-// Extensions that cannot carry readable copy. Everything else that is not
-// scanned gets named in the output: a file type this gate silently ignored would
-// otherwise read as a file type it cleared.
-const BINARY = /\.(png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|eot|pdf|mp4|webm)$/i;
+/** The extension used in the "not read" notice. A dotfile is its own name, not
+ *  an extension — ".nojekyll" is a file called .nojekyll. */
+const extensionOf = (path) => {
+  const name = basename(path);
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return "(no extension)";
+  return name.slice(dot);
+};
+
+/** Merge overlapping spans. Two matches that overlap in the original bytes are
+ *  the same claim seen through two views; disjoint ones are separate claims. */
+function countOccurrences(spans) {
+  const sorted = [...spans].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  let count = 0;
+  let end = -1;
+  for (const [start, stop] of sorted) {
+    if (start >= end) {
+      count++;
+      end = stop;
+    } else if (stop > end) {
+      end = stop;
+    }
+  }
+  return count;
+}
 
 let everything;
-let files;
 try {
   everything = walk(ROOT);
-  files = everything.filter((p) => SCAN_EXT.test(p));
 } catch {
   console.error(`✗ dist copy gate — no ${ROOT}/ to scan`);
   console.error(`  This runs after "astro build". Run "npm run build", not this script alone.`);
   process.exit(1);
 }
 
+const files = everything.filter((p) => SCAN_EXT.test(p));
 const errors = [];
 const allowed = [];
-const unused = new Set(ALLOWED.keys());
-const unread = new Set(
-  everything
-    .filter((p) => !SCAN_EXT.test(p) && !BINARY.test(p))
-    .map((p) => (/\.[A-Za-z0-9]+$/.exec(p) ?? ["(no extension)"])[0]),
+const unreadTypes = new Set(
+  everything.filter((p) => !SCAN_EXT.test(p) && !BINARY.test(p)).map(extensionOf),
 );
-let scanned = 0;
+
+// A Map, so two entries for the same file and string cannot both exist with only
+// one of them ever reachable.
+const index = new Map();
+for (const [at, entry] of ALLOWED.entries()) {
+  const id = `${entry.file}\u0000${entry.text.toLowerCase()}`;
+  if (index.has(id)) {
+    errors.push(`ALLOWED has two entries for ${entry.file} "${entry.text}" — delete one`);
+    continue;
+  }
+  index.set(id, { ...entry, at, used: false });
+}
+
+// Two dist files whose keys collapse together would share one allowance, so one
+// blessing would silently cover the other.
+const byKey = new Map();
+for (const path of files) {
+  const key = keyOf(path);
+  if (byKey.has(key)) {
+    errors.push(
+      `${path} and ${byKey.get(key)} both key to "${key}" — one allowlist entry would cover both`,
+    );
+  } else {
+    byKey.set(key, path);
+  }
+}
 
 for (const path of files) {
-  scanned++;
   const key = keyOf(path);
   const views = viewsOf(path, readFileSync(path, "utf8"));
 
-  // patternIndex + matched text -> { count, view, why }. The count is the
-  // highest any single view saw, never the sum, so three views of one string
-  // stay one hit.
-  const hits = new Map();
-  for (const view of views) {
-    for (const [index, { re, why }] of PATTERNS.entries()) {
+  // (pattern, matched text) -> { spans, view }. Keyed by the text as well as the
+  // pattern, because one alternation matches several words — §5's
+  // /\b(seguros?|aseguranza|p[óo]liza)\b/ finds both halves of "póliza de
+  // seguro" — and collapsing those into one entry would make the allowlist
+  // unreadable. Spans are original-byte ranges, so within a key a match found by
+  // several views is one occurrence, not several.
+  const found = new Map();
+  for (const { name, text, map } of views) {
+    for (const [at, { re }] of PATTERNS.entries()) {
       const global = new RegExp(re.source, re.flags.includes("g") ? re.flags : `${re.flags}g`);
-      const seen = new Map();
-      for (const m of view.text.matchAll(global)) {
-        const text = m[0].toLowerCase();
-        seen.set(text, (seen.get(text) ?? 0) + 1);
-      }
-      for (const [text, count] of seen) {
-        const id = `${index} ${text}`;
-        const prior = hits.get(id);
-        if (!prior || count > prior.count) hits.set(id, { text, count, view: view.name, why });
+      for (const m of text.matchAll(global)) {
+        if (!m[0].length) continue;
+        const matched = m[0].toLowerCase();
+        const id = `${at}\u0000${matched}`;
+        const span = [map[m.index], map[m.index + m[0].length - 1] + 1];
+        const seen = found.get(id) ?? { at, spans: [], text: matched, view: name };
+        seen.spans.push(span);
+        found.set(id, seen);
       }
     }
   }
 
-  for (const { text, count, view, why } of hits.values()) {
-    const at = ALLOWED.findIndex((a) => a.file === key && a.text.toLowerCase() === text);
-    const where = `${key}  "${text}" ×${count} [${view}]`;
+  for (const { at, spans, text, view: viewName } of found.values()) {
+    const { why } = PATTERNS[at];
+    const count = countOccurrences(spans);
+    const where = `${key}  "${text}" ×${count} [${viewName}]`;
+    const entry = index.get(`${key}\u0000${text}`);
 
-    if (at === -1) {
+    if (!entry) {
       errors.push(`${where} — ${why}`);
       continue;
     }
-    unused.delete(at);
-    const entry = ALLOWED[at];
+    entry.used = true;
     if (entry.count !== count) {
       errors.push(
         `${where} — allowed ×${entry.count}, found ×${count}. A changed count is a changed claim: ` +
@@ -287,17 +478,20 @@ for (const path of files) {
   }
 }
 
-for (const index of unused) {
-  const { file, text, count } = ALLOWED[index];
+for (const entry of index.values()) {
+  if (entry.used) continue;
   errors.push(
-    `${file}  "${text}" ×${count} is allowed but no longer appears — delete the entry ` +
-      `from scripts/check-dist-copy-gate.mjs`,
+    `${entry.file}  "${entry.text}" ×${entry.count} is allowed but no longer appears — delete the ` +
+      `entry from scripts/check-dist-copy-gate.mjs`,
   );
 }
 
+const notice = [...unreadTypes].sort();
+
 if (errors.length) {
-  console.error(`✗ dist copy gate (${scanned} files)`);
+  console.error(`✗ dist copy gate (${files.length} files)`);
   for (const e of errors) console.error(`  ${e}`);
+  for (const ext of notice) console.error(`  not read: ${ext} — add it to SCAN_EXT if it can carry copy`);
   console.error(`\n  The list is docs/copy-map.md §5, on the copy-map/en-es branch until it merges:`);
   console.error(`    git show origin/copy-map/en-es:docs/copy-map.md`);
   console.error(`  A source pragma cannot reach here — it is stripped by the build. A string that`);
@@ -306,6 +500,6 @@ if (errors.length) {
   process.exit(1);
 }
 
-console.log(`✓ dist copy gate (${scanned} files)`);
+console.log(`✓ dist copy gate (${files.length} files)`);
 for (const a of allowed) console.log(`  allowed: ${a}`);
-for (const ext of unread) console.log(`  not read: ${ext} — add it to SCAN_EXT if it can carry copy`);
+for (const ext of notice) console.log(`  not read: ${ext} — add it to SCAN_EXT if it can carry copy`);

--- a/scripts/copy-gate-patterns.mjs
+++ b/scripts/copy-gate-patterns.mjs
@@ -1,0 +1,54 @@
+// The copy-gate pattern list — docs/copy-map.md §5, on the copy-map/en-es branch
+// until it merges. Wayfinder #41 authored it; #57 moved it here so the source
+// gate and the dist gate match the *same* list. Two lists would drift, and a
+// pattern that exists in one gate and not the other is worse than no pattern:
+// it reads as covered.
+//
+// Editing this list changes what both gates forbid. §5 is the authority; this is
+// its transcription, not a place to loosen a rule that turned out inconvenient.
+//
+// Three §5 rules are judgement, not regex, and are checked by neither gate — they
+// stay human review at copy time:
+//   - copy claiming a visible per-trip fee breakdown in the app
+//   - invented per-trip price or earnings comparisons against Uber or Lyft
+//   - safety claims beyond Fla. Stat. § 627.748
+
+export const PATTERNS = [
+  // Gated until positioning obligations 1–3 all ship (driver pillar 2).
+  { re: /see the math/i, why: "gated: driver pillar 2, obligations 1–3" },
+  { re: /cuentas claras/i, why: "gated: driver pillar 2, obligations 1–3" },
+
+  // Gated until YeRide actually has insurance coverage (#48). There is no
+  // pass-through family today: insurance does not exist and card processing is
+  // Stripe billing the driver's own connected account, not YeRide forwarding it.
+  { re: /\bat[- ]cost\b/i, why: "gated on #48: nothing is passed through at cost" },
+  { re: /\bal costo\b/i, why: "gated on #48: nothing is passed through at cost" },
+  // The separator is required, as §5 writes it. The one-word "passthrough" is
+  // only ever an identifier here (ChargeFamily, the family filter), never a claim.
+  { re: /\bpass(es|ed|ing)?[- ]through\b/i, why: "gated on #48: the pass-through family has no members" },
+  { re: /\b(zero|without) markup\b/i, why: "gated on #48: the pass-through family has no members" },
+  { re: /\bsin (recargo|margen)\b/i, why: "gated on #48: the pass-through family has no members" },
+  // The same claim without any of the words above — §3.4's suspended family-2
+  // lead reads "Costs YeRide forwards without touching." / "…traslada sin tocar."
+  { re: /\bforwards?\b[^.]{0,30}\bwithout touching\b/i, why: "gated on #48: pass-through claim without the words" },
+  { re: /\btraslada\b[^.]{0,30}\bsin tocar\b/i, why: "gated on #48: pass-through claim without the words" },
+  { re: /\binsurance\b/i, why: "gated on #48: YeRide carries no coverage" },
+  { re: /\b(seguros?|aseguranza|p[óo]liza)\b/i, why: "gated on #48: YeRide carries no coverage" },
+  { re: /\bcoverage\b/i, why: "gated on #48: YeRide carries no coverage" },
+  { re: /\bcobertura\b/i, why: "gated on #48: YeRide carries no coverage" },
+
+  // Never claimed, gate or no gate.
+  { re: /\blocked\b/i, why: "never claimed: fares are metered, not locked" },
+  { re: /\bupfront (price|pricing)\b/i, why: "never claimed: fares are metered, not locked" },
+  { re: /\bprecio (fijo|cerrado|garantizado)\b/i, why: "never claimed: fares are metered, not locked" },
+  { re: /\bno surprises\b/i, why: "never claimed: fares are metered, not locked" },
+  { re: /\bsin sorpresas\b/i, why: "never claimed: fares are metered, not locked" },
+  { re: /\bno surge\b(?![ \t]+today)/i, why: 'never claimed: only "no surge today" is permitted (§3.4)' },
+  { re: /\bnunca\b[^.]{0,20}\brecargo\b/i, why: 'never claimed: only "no surge today" is permitted (§3.4)' },
+  { re: /\bcheape(st|r)\b/i, why: "never claimed: no price-leadership claim" },
+  { re: /\blowest (fees|fares|price)\b/i, why: "never claimed: no price-leadership claim" },
+  { re: /\bm[áa]s barat[oa]s?\b/i, why: "never claimed: no price-leadership claim" },
+  { re: /\bm[áa]s econ[óo]mico\b/i, why: "never claimed: no price-leadership claim" },
+  { re: /\$[ \t]?\d/, why: "never claimed: no hard-coded money — every figure is fetched live" },
+  { re: /\b\d[\d,.]*[ \t]*(dollars|USD)\b/i, why: "never claimed: no hard-coded money — every figure is fetched live" },
+];


### PR DESCRIPTION
Closes #57.

The source copy gate matches lines of source text, so it is blind to everything the build does to that text. This adds the second layer that measures the promise itself — **a forbidden claim must not reach the shipped site** — by reading what is actually shipped.

## What is here

- **`scripts/copy-gate-patterns.mjs`** — the §5 list, extracted. Both gates import it. Two lists would drift, and a pattern present in one gate and absent from the other is worse than no pattern: it reads as covered.
- **`scripts/check-dist-copy-gate.mjs`** — the new gate.
- **`scripts/check-copy-gate.mjs`** — unchanged except for the import and one addition: it now fails on a Greek or Cyrillic letter.
- Last step of `npm run build`; `npm run check:dist` runs it alone.

## Scanning built HTML alone would have caught almost nothing

`/fees` renders its charge rows **client-side**. Its copy exists only in `dist/_astro/FeeSchedule.*.js` and never appears in `dist/fees/index.html` — verified, zero hits there. So the gate reads every publicly fetchable file, comments included, which is the same call the source gate already makes about HTML comments.

## The four sub-questions

**1. The allowlist has no home in `dist/`.** Source pragmas are stripped by the build, so this carries its own list, keyed to the **hash-free path**, the **matched text** and an **exact count**. An entry that stops matching — or matches a different number of times — fails, exactly as a stale pragma does. Sixteen entries: the ten dormant §3.4 pass-through strings, the five legal-page sentences that *deny* YeRide has insurance, and one XML comment in a vendored brand asset. A reason must name an issue or start with `vendored:`; there is no third kind.

The dormant §3.4 copy **stays bundled** rather than being deleted. Deleting it would also delete the source pragmas, and with them #41's check that fails the build the moment a charge *is* filed into `passthrough` — trading a loud failure for a silent empty panel.

**2. Where it runs.** Last step of `npm run build`, after `astro build`, so a failure blocks the artifact upload in the same job. It **cannot** run in `checks.yml`, which is dependency-free by design, so it is a pre-deploy backstop rather than a PR-time one — the source gate stays the PR-time layer. That gap is stated in the script header, not implied away.

**3. How much normalisation is honest.** Character references decoded in **one** left-to-right pass, so `&amp;#36;9` — which renders as literal text — is not invented into a hit. Invisible characters removed, JS `\u`/`\x` escapes resolved, whitespace collapsed. Markup handled by matching **three views** of each HTML file:

| view | catches | can it fabricate? |
|---|---|---|
| tags intact | the plain reading | no |
| tags → nothing | `Insur<span>ance</span>` | no — removing a tag removes the gap, so `<li>zero</li><li>markup</li>` becomes `zeromarkup` |
| tags → space | a phrase split across two elements | **yes** — so hits name the view that found them |

On the real site the fabricating view produces **zero** false positives. A hit is counted once per matched string at the highest count any view saw, so the views cannot inflate each other.

**Homoglyph folding is refused.** A confusables table's wrong entries would invent failures in Spanish copy, which is full of legitimate non-ASCII. The confusable is itself the defect, so the **source** gate fails on a Greek or Cyrillic letter — unambiguous there because `src/` and `public/` are wholly authored here, where a vendored bundle may legitimately carry other scripts. Accented Latin (á, é, ñ, ü) is untouched.

**4. The runtime residual** stays with #56, which asks the live endpoint what it publishes and fails the deploy on a charge id this site cannot name — that being exactly the case where `FeeSchedule.astro` falls back to printing the backend's own `description` verbatim.

## What it still cannot do

Runtime-assembled copy. Server-side assembly lands in the built HTML and **is** caught; client-side assembly (`["lowest","fees"].join(" ")`) is not, and no static check can see it. The ticket listed this as subsumed — it is only half-subsumed, and the header says so.

## Verification

`npm run build` green end-to-end. **28 positive controls** against a real build, all passing:

- **fails** on: plain phrase · newline inside a phrase (ordinary Prettier wrapping) · `at&nbsp;cost` · `&#36;` · `&#x24;` · `&dollar;` · word split by a tag · phrase split across elements · zero-width space · soft hyphen · word joiner · JS `$` · JS `\x24` · a claim hidden in an HTML comment · a claim in a `meta` attribute · Cyrillic homoglyph in src · Greek homoglyph in src
- **does not fire** on: double-encoded `&amp;#36;` · the one-word `passthrough` identifier · "No surge today" (permitted by §3.4) · accented Spanish
- **allowlist discipline**: count drift fails · an entry matching nothing fails · a changed content hash keeps the entry matching

One find worth flagging: the brand lockup SVG carries an XML comment reading *"Typeface locked by the brand-typography decision (issue #8)"*, which trips §5's `\blocked\b`. It is vendored and not editable here, hence the `vendored:` entry rather than a pattern change — §5 is the copy map's authority, not this ticket's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)