### PR TITLE
Name the service area every fare estimate is for (wayfinder #62)

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -249,13 +249,24 @@ loader supplies autocomplete, the map and Directions, and the fares come from th
 Firebase callable `estimateFares` at submit time. `setOptions({ language })` is passed
 the page's language, or the ES page gets English place names and an English "18 mins".
 
-**Why it names a service area** (wayfinder #62). Every quote is for
+**Why it says what it is priced for** (wayfinder #62). Every quote is for
 `DEFAULT_SERVICE_AREA_ID`, whatever the rider typed, so the page states which area —
 otherwise the map underneath implies the rider's own and a Chicago route reads as a
 Chicago price. The line is rendered in the frontmatter, not from the response, because
 it must stand in every state including a failed estimate. The constant lives in
 `src/lib/serviceArea.ts` rather than `src/lib/fareEstimate.ts` so that reading it here
 does not import `src/lib/firebase.ts`, which calls `initializeApp` at module scope.
+
+The label is **"Priced for"**, not "Service area": the latter is the site's coverage
+vocabulary (`/es/fees` labels its picker "Área de servicio", and both legal documents
+use it that way), so on a page showing the rider's own route it would read as a claim
+that the ride is served — the very implicature the ticket removed. The note carries
+availability instead, and says a price is not a promise of service rather than naming
+the served set, which would be a count nothing on the site checks. The area's bilingual
+name is read straight out of `serviceAreaNames`, **not** via `serviceAreaName()`: that
+helper humanises an unknown identifier ("Us Fl South Florida") so `/fees` can render an
+area it has never heard of, which on this page would publish an English-derived string
+on `/es/fare-estimate`. Here a missing name is a defect, so it fails the build.
 
 ### LegalDocument
 
@@ -322,10 +333,14 @@ That cost is the point: adding one is a decision.
    abandoned journey can never be rendered under a map showing a different one.
 4. **§3.5's "Outside area" line is not shipped.** The page asks for
    `us-fl-south-florida` on every call and cannot know where the rider is, so it has no
-   condition that makes the sentence true — see #62.
+   condition that makes the sentence true. #62 established why — a service area is a
+   circle no endpoint publishes yet — and shipped the "Priced for" pair instead; the
+   line itself waits on #73.
 
-**Related:** `src/lib/fareEstimate.ts` (callable contract), `src/lib/firebase.ts`
-(callable region), `src/i18n/fareEstimateCopy.ts` (page copy, EN/ES).
+**Related:** `src/lib/fareEstimate.ts` (callable contract), `src/lib/serviceArea.ts`
+(the area the page prices), `src/lib/firebase.ts` (callable region),
+`src/i18n/fareEstimateCopy.ts` (page copy, EN/ES), `src/i18n/feeLabels.ts`
+(`serviceAreaNames`, read in the frontmatter for the area's bilingual name).
 
 ## Page-Specific Components
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -249,6 +249,14 @@ loader supplies autocomplete, the map and Directions, and the fares come from th
 Firebase callable `estimateFares` at submit time. `setOptions({ language })` is passed
 the page's language, or the ES page gets English place names and an English "18 mins".
 
+**Why it names a service area** (wayfinder #62). Every quote is for
+`DEFAULT_SERVICE_AREA_ID`, whatever the rider typed, so the page states which area —
+otherwise the map underneath implies the rider's own and a Chicago route reads as a
+Chicago price. The line is rendered in the frontmatter, not from the response, because
+it must stand in every state including a failed estimate. The constant lives in
+`src/lib/serviceArea.ts` rather than `src/lib/fareEstimate.ts` so that reading it here
+does not import `src/lib/firebase.ts`, which calls `initializeApp` at module scope.
+
 ### LegalDocument
 
 The whole body of `/privacy-policy`, `/terms` and their ES twins (wayfinder #44). One

--- a/scripts/check-fee-labels.mjs
+++ b/scripts/check-fee-labels.mjs
@@ -32,6 +32,7 @@
 import { readFileSync, existsSync } from "node:fs";
 
 const LABELS = "src/i18n/feeLabels.ts";
+const SERVICE_AREA = "src/lib/serviceArea.ts";
 const TIMEOUT_MS = 10_000;
 
 // The same variable the site is built against, so the check reads exactly the
@@ -52,6 +53,16 @@ function skip(why) {
   console.log(`- fee labels SKIPPED — ${why}`);
   console.log(`  Nothing was checked: ids the site cannot name would not be seen.`);
   process.exit(0);
+}
+
+/** One capture group out of a source file, or throw. Fails CLOSED on purpose:
+ *  a reader that shrugs and returns "" would turn a renamed constant into a
+ *  silent pass, which is the failure mode this whole script exists to refuse
+ *  (#59's review found exactly that bug in a source reader). */
+function matchOne(src, re, what) {
+  const m = re.exec(src);
+  if (!m) throw new Error(`could not read ${what} — has it been renamed?`);
+  return m[1];
 }
 
 /** Top-level keys of an exported object literal, read out of the TypeScript
@@ -165,6 +176,7 @@ for (const area of areas) {
 
 const errors = [];
 const missingCharges = [];
+const missingAreas = [];
 
 for (const [id, { description, areas: seenIn }] of charges) {
   if (knownCharges.has(id)) continue;
@@ -179,9 +191,32 @@ for (const [id, { description, areas: seenIn }] of charges) {
 
 for (const area of areas) {
   if (knownAreas.has(area.id)) continue;
+  missingAreas.push(area.id);
   errors.push(
     `service area "${area.id}" is offered by the picker and ${LABELS} does not cover it\n` +
       `      both languages would fall back to the humanised identifier`,
+  );
+}
+
+// The one area /fare-estimate hard-codes must still be one the endpoint serves
+// (#62). Unlike a stale LABEL — harmless, and only a notice below — a stale
+// DEFAULT_SERVICE_AREA_ID is a live defect: `estimateFares` throws `not-found`
+// for every rider on the page while the page keeps naming the area it priced
+// for, because that line is server-rendered and stands in every state by
+// design. Nothing else checks it; the id is written in three places that no
+// one derives from the others (here, the site constant, and yeride-functions'
+// own DEFAULT_AREA_ID), so drift is silent everywhere else.
+const defaultArea = matchOne(
+  readFileSync(SERVICE_AREA, "utf8"),
+  /DEFAULT_SERVICE_AREA_ID\s*=\s*"([^"]+)"/,
+  `DEFAULT_SERVICE_AREA_ID in ${SERVICE_AREA}`,
+);
+const defaultAreaUnserved = !areas.some((a) => a.id === defaultArea);
+if (defaultAreaUnserved) {
+  errors.push(
+    `/fare-estimate prices every fare for "${defaultArea}" and getFeeSchedule does not serve it\n` +
+      `      it offers ${areas.map((a) => a.id).join(", ") || "no areas at all"}\n` +
+      `      so estimateFares answers not-found for every rider while the page still names it`,
   );
 }
 
@@ -193,14 +228,26 @@ const scope =
 if (errors.length) {
   console.error(`✗ fee labels (${scope})`);
   for (const e of errors) console.error(`  ${e}`);
-  console.error(`\n  Both maps are in ${LABELS}.`);
+  // Each hint names the cause it actually belongs to. An unconditional hint is
+  // a wrong cause named for every other failure — the fault this repo has
+  // re-opened tickets over (#47, #57, #59).
+  if (missingCharges.length || missingAreas.length) {
+    console.error(`\n  Both maps are in ${LABELS}.`);
+  }
   if (missingCharges.length) {
     console.error(`  A charge needs an EN and an ES label, a "family" and a "payer". Neither family`);
     console.error(`  nor payer is a database field, so both are editorial decisions a human has to`);
     console.error(`  make: getting them wrong states something false about YeRide's economics on`);
     console.error(`  the page that exists to be trusted about them (copy-map §2.3).`);
   }
-  console.error(`  An area needs a display name in both languages — it is brand copy, not data (#47).`);
+  if (missingAreas.length) {
+    console.error(`  An area needs a display name in both languages — it is brand copy, not data (#47).`);
+  }
+  if (defaultAreaUnserved) {
+    console.error(`  The area /fare-estimate prices for is ${SERVICE_AREA}, and it is not a label —`);
+    console.error(`  naming it here would not help. Either the area moved and the constant follows it,`);
+    console.error(`  or it should not have moved (#62).`);
+  }
   console.error(`  Endpoint: ${endpoint}`);
   process.exit(1);
 }

--- a/src/components/FareEstimatePage.astro
+++ b/src/components/FareEstimatePage.astro
@@ -16,6 +16,8 @@
 // The stack is unchanged: Firebase callable `estimateFares` + the Google Maps
 // loader (maps, places, marker, routes).
 import { fareEstimateCopy } from "../i18n/fareEstimateCopy";
+import { serviceAreaName } from "../i18n/feeLabels";
+import { DEFAULT_SERVICE_AREA_ID } from "../lib/serviceArea";
 import type { Lang } from "../i18n/feesCopy";
 
 export interface Props {
@@ -24,6 +26,17 @@ export interface Props {
 const { lang } = Astro.props;
 const t = fareEstimateCopy[lang];
 const esPrefix = lang === "es" ? "/es" : "";
+
+// The area every quote on this page is for (#62). Named from the same constant
+// the request is built from, through the same bilingual map /fees uses — so a
+// new area is named once, in one place, and #56 fails the deploy if it is not.
+// The second argument is the fallback identifier the humaniser would use; the
+// id is all this page has, and it is only reached if the map loses this key.
+const areaName = serviceAreaName(
+  DEFAULT_SERVICE_AREA_ID,
+  DEFAULT_SERVICE_AREA_ID,
+  lang,
+);
 ---
 
 <main>
@@ -102,11 +115,29 @@ const esPrefix = lang === "es" ? "/es" : "";
       </div>
 
       {/*
+        WHERE the quote applies. The page prices one area whatever the rider
+        typed, so it says which rather than letting the map underneath imply
+        the rider's own (#62).
+
+        Rendered here rather than from the response for the same reason the
+        limit note below is: it has to stand in EVERY state — before a route is
+        entered, and when the estimate fails — and a rider who never gets a
+        number is still owed the reason. `estimateFares` echoes back the id it
+        was given and never another, so the response could not correct this
+        anyway.
+      */}
+      <p class="mt-6 max-w-xl text-[15px] text-ink/60">
+        <span class="font-bold text-ink">{t.areaLabel}:</span>
+        {areaName}
+      </p>
+      <p class="mt-1 max-w-xl text-[15px] text-ink/60">{t.areaNote}</p>
+
+      {/*
         The limit note stands in every state, not only alongside a result: it is
         what this page is for, and a rider reading an error or waiting on a
         quote is owed it as much as one reading a number.
       */}
-      <p class="mt-6 max-w-xl text-[15px] text-ink/60">{t.limitNote}</p>
+      <p class="mt-4 max-w-xl text-[15px] text-ink/60">{t.limitNote}</p>
 
       <div data-results hidden>
         <section class="mt-10">
@@ -494,7 +525,9 @@ const esPrefix = lang === "es" ? "/es" : "";
     // every call and has no way to know where the rider is, so a rider in
     // Chicago is quoted South Florida rates and `functions/not-found` means
     // "South Florida has no services configured" — a fault, not a geography.
-    // Saying "We're not in that area yet" there would be false. Filed as #62.
+    // Saying "We're not in that area yet" there would be false. The page states
+    // the area it priced instead (#62); the row itself waits on #73, which
+    // waits on yeapptech/yeride-functions#45 to publish each area's circle.
     console.error("[fare-estimate]", err);
     return t.serviceError;
   }

--- a/src/components/FareEstimatePage.astro
+++ b/src/components/FareEstimatePage.astro
@@ -16,7 +16,7 @@
 // The stack is unchanged: Firebase callable `estimateFares` + the Google Maps
 // loader (maps, places, marker, routes).
 import { fareEstimateCopy } from "../i18n/fareEstimateCopy";
-import { serviceAreaName } from "../i18n/feeLabels";
+import { serviceAreaNames } from "../i18n/feeLabels";
 import { DEFAULT_SERVICE_AREA_ID } from "../lib/serviceArea";
 import type { Lang } from "../i18n/feesCopy";
 
@@ -27,16 +27,30 @@ const { lang } = Astro.props;
 const t = fareEstimateCopy[lang];
 const esPrefix = lang === "es" ? "/es" : "";
 
-// The area every quote on this page is for (#62). Named from the same constant
-// the request is built from, through the same bilingual map /fees uses — so a
-// new area is named once, in one place, and #56 fails the deploy if it is not.
-// The second argument is the fallback identifier the humaniser would use; the
-// id is all this page has, and it is only reached if the map loses this key.
-const areaName = serviceAreaName(
-  DEFAULT_SERVICE_AREA_ID,
-  DEFAULT_SERVICE_AREA_ID,
-  lang,
-);
+// The area every quote on this page is for (#62), named from the same constant
+// the request is built from and through the same bilingual map /fees uses.
+//
+// The map is read DIRECTLY rather than through `serviceAreaName`, whose job is
+// to survive an area the site has never heard of: it humanises the identifier,
+// which turns "us-fl-south-florida" into "Us Fl South Florida" and publishes
+// that English-derived string on the SPANISH page too. That is the right
+// behaviour for /fees, which renders whatever the endpoint lists and must not
+// drop an area it cannot name — and the wrong behaviour here, where there is
+// exactly one hard-coded area whose name is site-authored copy. A missing key
+// is then not a fallback but a defect, so it stops the build.
+//
+// `scripts/check-fee-labels.mjs` (#56) does NOT cover this: it needs the
+// network, runs outside `npm run build`, and skips when the endpoint does not
+// answer — so a deleted key plus an unreachable endpoint ships the humanised
+// string with every gate green. This throw needs no network.
+const areaName = serviceAreaNames[DEFAULT_SERVICE_AREA_ID]?.[lang];
+if (!areaName) {
+  throw new Error(
+    `serviceAreaNames has no ${lang} name for "${DEFAULT_SERVICE_AREA_ID}". ` +
+      `/fare-estimate states the area every fare is priced for, so without a ` +
+      `site-authored name it would publish a humanised id — in both languages.`,
+  );
+}
 ---
 
 <main>
@@ -126,11 +140,19 @@ const areaName = serviceAreaName(
         was given and never another, so the response could not correct this
         anyway.
       */}
-      <p class="mt-6 max-w-xl text-[15px] text-ink/60">
-        <span class="font-bold text-ink">{t.areaLabel}:</span>
+      {/*
+        Contrast: the area name carries the whole claim, so it sits at full
+        `text-ink` (14.9:1) rather than the `text-ink/60` used for secondary
+        prose — which measures 4.16:1 on paper and so misses WCAG AA's 4.5:1
+        for normal text. The note is secondary but is still a disclosure, so it
+        takes `/70` (5.7:1) — the smallest step that clears AA while staying
+        visibly quieter than the fact above it.
+      */}
+      <p class="mt-6 max-w-xl text-[15px] text-ink">
+        <span class="font-bold">{t.areaLabel}:</span>
         {areaName}
       </p>
-      <p class="mt-1 max-w-xl text-[15px] text-ink/60">{t.areaNote}</p>
+      <p class="mt-1 max-w-xl text-[15px] text-ink/70">{t.areaNote}</p>
 
       {/*
         The limit note stands in every state, not only alongside a result: it is

--- a/src/i18n/fareEstimateCopy.ts
+++ b/src/i18n/fareEstimateCopy.ts
@@ -34,6 +34,18 @@ const en = {
   /** "{n} seats" — §3.5 gives the row with the placeholder in it. */
   seats: "{n} seats",
   limitNote: "Estimates are estimates — the meter decides.",
+  /**
+   * §3.5, amended by #62. The page prices ONE area whatever the rider typed,
+   * so it says which — the label carries the area name, the note carries the
+   * consequence.
+   *
+   * The name is interpolated, so neither string may govern it: Spanish would
+   * need "de/del/de la" by name and "en {area}" is ungrammatical for "Sur de
+   * la Florida". A colon in the label and "this area" in the note keep both
+   * languages correct for any area name the map ever holds.
+   */
+  areaLabel: "Service area",
+  areaNote: "Every estimate here is at this area's rates, even for a route outside it.",
   feeLink: "See the full fee schedule",
   noRouteError: "We couldn't find a route between those two places.",
   serviceError: "We couldn't get an estimate right now. Try again in a moment.",
@@ -42,8 +54,15 @@ const en = {
   // call and has no way to know where the rider is, so nothing it can observe
   // means "you are outside our area" — `functions/not-found` means South
   // Florida itself has no services configured. Shipping the string would put a
-  // sentence on screen the site cannot know to be true. Filed as #62; it
-  // returns when the site can answer the question the copy asks.
+  // sentence on screen the site cannot know to be true.
+  //
+  // #62 settled WHY the site cannot know: a service area is a circle
+  // (`latitude`/`longitude`/`radius` on every `serviceAreas/{id}` document, and
+  // yeride-mobile's `ResolveActiveServiceArea` already tests it with Haversine),
+  // but `getFeeSchedule` publishes only `{id, identifier}`. Until
+  // yeapptech/yeride-functions#45 publishes the circle, no condition on this
+  // page means "you are outside our area" — so #62 shipped what IS true, the
+  // `areaLabel`/`areaNote` pair below, and the row itself waits for #73.
 };
 
 export const fareEstimateCopy: Record<Lang, typeof en> = {
@@ -64,6 +83,9 @@ export const fareEstimateCopy: Record<Lang, typeof en> = {
     fareCaption: "tarifa estimada",
     seats: "{n} asientos",
     limitNote: "Un estimado es un estimado — el taxímetro decide.",
+    areaLabel: "Zona de servicio",
+    areaNote:
+      "Todo estimado aquí usa las tarifas de esta zona, incluso para una ruta fuera de ella.",
     feeLink: "Ver el tarifario completo",
     noRouteError: "No encontramos una ruta entre esos dos lugares.",
     serviceError: "No pudimos calcular el estimado ahora. Intenta de nuevo en un momento.",

--- a/src/i18n/fareEstimateCopy.ts
+++ b/src/i18n/fareEstimateCopy.ts
@@ -39,13 +39,29 @@ const en = {
    * so it says which — the label carries the area name, the note carries the
    * consequence.
    *
+   * NOT "Service area" (the first attempt, corrected by review). That is the
+   * site's COVERAGE vocabulary — `/es/fees` labels its picker "Área de
+   * servicio" and both legal documents use it in that sense — so on a page
+   * that has just drawn the rider's own route, "Service area: South Florida"
+   * reads as *your ride is handled under our South Florida service area*: the
+   * exact implicature this ticket exists to remove, restated in the site's own
+   * words. "Priced for" makes the pricing claim and no coverage claim, and it
+   * cannot collide with `/fees`, which is naming a different thing.
+   *
+   * The note then has to carry availability, because nothing else on the page
+   * does: naming the area a price came from does not tell a rider YeRide is
+   * absent where they are. It says a price is not a promise of service rather
+   * than naming the served set, because the served set is a COUNT — it would
+   * be false the day an area is added and nothing on the site checks it.
+   *
    * The name is interpolated, so neither string may govern it: Spanish would
    * need "de/del/de la" by name and "en {area}" is ungrammatical for "Sur de
    * la Florida". A colon in the label and "this area" in the note keep both
    * languages correct for any area name the map ever holds.
    */
-  areaLabel: "Service area",
-  areaNote: "Every estimate here is at this area's rates, even for a route outside it.",
+  areaLabel: "Priced for",
+  areaNote:
+    "Every estimate here uses this area's rates, even for a route outside it — a price is not a promise that YeRide operates there.",
   feeLink: "See the full fee schedule",
   noRouteError: "We couldn't find a route between those two places.",
   serviceError: "We couldn't get an estimate right now. Try again in a moment.",
@@ -62,7 +78,7 @@ const en = {
   // but `getFeeSchedule` publishes only `{id, identifier}`. Until
   // yeapptech/yeride-functions#45 publishes the circle, no condition on this
   // page means "you are outside our area" — so #62 shipped what IS true, the
-  // `areaLabel`/`areaNote` pair below, and the row itself waits for #73.
+  // `areaLabel`/`areaNote` pair ABOVE, and the row itself waits for #73.
 };
 
 export const fareEstimateCopy: Record<Lang, typeof en> = {
@@ -83,9 +99,13 @@ export const fareEstimateCopy: Record<Lang, typeof en> = {
     fareCaption: "tarifa estimada",
     seats: "{n} asientos",
     limitNote: "Un estimado es un estimado — el taxímetro decide.",
-    areaLabel: "Zona de servicio",
+    areaLabel: "Precio calculado para",
+    // "esta área", not "esta zona": `/es/fees` already says "para esta área"
+    // (feesCopy.ts) and both legal documents say "área de servicio", so a new
+    // "zona" would give the Spanish site two words for one thing, one click
+    // apart — the leak #47 kept these names site-side to prevent.
     areaNote:
-      "Todo estimado aquí usa las tarifas de esta zona, incluso para una ruta fuera de ella.",
+      "Todo estimado aquí usa las tarifas de esta área, incluso para una ruta fuera de ella — un precio no significa que YeRide opere allí.",
     feeLink: "Ver el tarifario completo",
     noRouteError: "No encontramos una ruta entre esos dos lugares.",
     serviceError: "No pudimos calcular el estimado ahora. Intenta de nuevo en un momento.",

--- a/src/lib/fareEstimate.ts
+++ b/src/lib/fareEstimate.ts
@@ -1,5 +1,6 @@
 import { httpsCallable } from "firebase/functions";
 import { functions } from "./firebase";
+import { DEFAULT_SERVICE_AREA_ID } from "./serviceArea";
 
 export interface ServiceEstimate {
   serviceId: string;
@@ -49,7 +50,6 @@ interface FareEstimateRequest {
   duration: number;
 }
 
-const DEFAULT_SERVICE_AREA_ID = "us-fl-south-florida";
 
 export async function getEstimates(
   distance: number,

--- a/src/lib/fareEstimate.ts
+++ b/src/lib/fareEstimate.ts
@@ -50,7 +50,6 @@ interface FareEstimateRequest {
   duration: number;
 }
 
-
 export async function getEstimates(
   distance: number,
   duration: number,

--- a/src/lib/serviceArea.ts
+++ b/src/lib/serviceArea.ts
@@ -1,0 +1,28 @@
+// The service area /fare-estimate prices (wayfinder #62).
+//
+// It lives here rather than in `./fareEstimate` for one mechanical reason: the
+// page has to NAME this area in its markup, and `./fareEstimate` imports
+// `./firebase`, which calls `initializeApp` at module scope. Importing it from
+// Astro frontmatter would run Firebase initialisation during the static build
+// to read a string constant. This module has no dependencies at all.
+
+/**
+ * The one area this page prices — asked for on EVERY call, whatever the rider
+ * typed. `estimateFares` returns the id it was given and never another
+ * (yeride-functions `handlers/estimate-fares.js`: `return {serviceAreaId,
+ * estimates}`), so a route in Chicago comes back priced at South Florida rates
+ * and rendered as a fare for a ride YeRide does not run.
+ *
+ * The page therefore states which area it quoted, and the request and the label
+ * read THIS constant — a second literal spelling the area into the copy would
+ * go stale silently the moment this one changed, and the page would then name
+ * the wrong market while pricing another.
+ *
+ * Choosing the area from the rider's pickup instead is #73, and it is not built
+ * here because it cannot be exercised yet: the test is point-in-circle against
+ * each area's `latitude`/`longitude`/`radius`, and `getFeeSchedule` publishes
+ * only `{id, identifier}` today (yeride-functions#45 adds the circle). The
+ * semantics are already settled — yeride-mobile's `ResolveActiveServiceArea`
+ * does Haversine, inclusive at the boundary, first match in document-id order.
+ */
+export const DEFAULT_SERVICE_AREA_ID = "us-fl-south-florida";


### PR DESCRIPTION
Resolves #62.

`/fare-estimate` asks `estimateFares` for `us-fl-south-florida` on **every** call. Two Chicago addresses resolve to a real Google route, are quoted South Florida rates, and are rendered as a fare for a ride YeRide does not run — with nothing on the page saying so.

## What the investigation found

The ticket framed this as an open question — where would bounds even come from, a backend field, a site-side box, or Google's geocoding? It has an answer already, in three places:

- **A service area is a circle, and always has been.** Every `serviceAreas/{id}` document carries `latitude`, `longitude` and `radius` in metres. yeride-mobile's `src/data/dto/ServiceAreaDoc.ts` parses exactly those ("a CIRCULAR region. Polygons are not used."); yeride-admin's `ServiceAreaEditSheet.tsx` is where an admin types them; yeride-functions' own `get-fee-schedule.test.js` fixture already sets `latitude: 26.1`.
- **The semantics are already decided.** yeride-mobile resolves this properly — Haversine point-in-circle, inclusive at the boundary (`ServiceArea.ts`), first match in document-id order on overlap (`ResolveActiveServiceArea.ts`) — and `ServiceArea.ts`'s own comment says the legacy app "just takes the first area unconditionally", which is the same bug this page has.
- **`getFeeSchedule` already reads the documents and throws the geography away.** `readAreas` does `db.getAll(...refs)` to pick out `identifier`, then publishes `{id, identifier}`. Publishing the circle costs **zero extra Firestore reads**.

So the site is not missing a geography model — it is missing a field. Filed as **yeapptech/yeride-functions#45**, with the acceptance rules written to match this repo's own: an absent or non-finite circle is **omitted, never defaulted**, because a `0` radius silently means "nobody is inside" and a huge one "everybody is" — the `$0.00`-masking-a-gap failure `/fees` exists to refuse.

## What this PR ships

The honest floor, which needs no new data: **the page says which area it priced**, in both languages.

```
Service area: South Florida          Zona de servicio: Sur de la Florida
Every estimate here is at this       Todo estimado aquí usa las tarifas de
area's rates, even for a route       esta zona, incluso para una ruta fuera
outside it.                          de ella.
```

Four decisions inside that:

1. **One constant, not two.** The label and the request both read `DEFAULT_SERVICE_AREA_ID`. A second literal spelling the area into copy would go stale silently and the page would then name one market while pricing another.
2. **The constant moved to `src/lib/serviceArea.ts`.** `src/lib/fareEstimate.ts` imports `./firebase`, which calls `initializeApp` at module scope — importing it from Astro frontmatter would run Firebase initialisation during the static build to read a string. The new module has no dependencies.
3. **Rendered server-side, not from the response.** It has to stand in *every* state, including a failed estimate (verified — see below). `estimateFares` echoes back the id it was given and never another, so the response could not correct it anyway.
4. **Neither string may govern the area name.** It is interpolated through the same bilingual map `/fees` uses, and Spanish needs "de/del/de la" chosen by name — `"en {area}"` is ungrammatical for "Sur de la Florida". Hence the colon in the label and "this area" / "esta zona" in the note: correct for any area name that map ever holds. For the same reason neither string claims **how many** areas exist — a count would be a fact nothing on the site checks.

## What this PR deliberately does *not* ship

Resolving the area from the rider's pickup, and with it §3.5's long-unshipped "Outside area" row. That code cannot be exercised until an endpoint publishes the circle, and *"a guard whose enforcement is assumed is this map's recurring failure"* (#59). Split out as **#73**, blocked on functions#45, and it does **not** block the ship: this removes the false implicature, #73 removes the wrong number.

## One correction to the ticket's framing

The ticket implies nothing on the site states where YeRide operates. The footer does carry "Built in South Florida." / "Hecho en el Sur de la Florida." — but that is a claim about where YeRide is *built*, not where it *runs*, and no rider would read it as availability. No copy anywhere states the service area; that is still true.

## Verification

- `npm run build` green end to end — route parity, source copy gate, env gate (#59), `astro check` **0 errors / 0 warnings**, build, dist copy gate (#57). No new copy-gate allowances.
- Rendered strings confirmed in the built HTML for `/fare-estimate` and `/es/fare-estimate` — the block is static, so #57's gate sees it.
- Browser, both languages: the block renders correctly and, because the local Maps key is a placeholder, the map failed to load — which **positively confirmed** the "stands in every state" claim rather than assuming it.
- Copy map ↔ code checked **character-for-character** across all four new cells (script, not eyeball). Amended on `copy-map/en-es` as `3e38ca2`.
- Mobile width: **a true 390 px render** (iframe, `innerWidth: 390`), 0 horizontal overflow in EN and ES. (The first pass could only measure at a 350 px column because Chrome would not shrink the window; the review retired that hedge.)
- `src/lib/fareEstimate.ts` is a CRLF file; it was patched programmatically and verified to have gained **0 bare LF**, so the diff is the change and not the line endings.

## Not verified

The live `estimateFares` / Directions path, for want of local API keys — unchanged from #38, and untouched by this PR, which adds no client-side logic at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Independently reviewed 2026-08-03 — standards + spec + adversarial

Reviewed at `4dc9563`; fixes in `bfad463` (+ copy map `6d05e01`). **The copy in the first pass was wrong in two independent ways, both about the thing this PR exists to fix.** Full write-up in the [resolution comment on #62](https://github.com/yeapptech/yeride-website/issues/62#issuecomment-5169257692).

- **The label restated the implicature it removed.** "Service area" is the site's *coverage* vocabulary (`/es/fees` picker, both legal documents), so on a page showing the rider's own route it read as *your ride is served* — and gave the Spanish site two nouns for one concept one click apart from a link this page itself carries. Now **"Priced for" / "Precio calculado para"**, and "esta área" not "esta zona".
- **The note said nothing about availability** — it named the rate card and read closer to a promise that out-of-area routes get priced. It now ends *"a price is not a promise that YeRide operates there"*, which stays true however many areas exist.
- **A humanised id could ship, proven not argued.** Deleting the `serviceAreaNames` key made the full build pass green and published **`Us Fl South Florida`** on both language pages. The name is now read directly from the map and a missing one **throws at build time**.
- **A comment claimed a guarantee that did not exist** (`#56` "fails the deploy") — `#56` needs the network, runs outside `npm run build`, and skips when the endpoint is silent. Corrected, and the real gap closed: `#56` now fails when the area this page prices for is not one `getFeeSchedule` serves, with its hints **gated per cause**.
- **Contrast.** `text-ink/60` is 4.16:1 on paper, under AA — and emphasis was inverted, with the generic label bold at 14.89:1 and the market name below the floor. Name now full `text-ink`, note `/70`. Site-wide instance filed as #76.
- **Two corrections to the record**: the Haversine quotes are in `ServiceArea.ts`, not `ResolveActiveServiceArea.ts`; and "no rider would read the footer as availability" is undercut by the brand's own *"Built in South Florida, for South Florida."*

**Also filed, not fixed here:** #75 — `/es/`'s home meta says "tarifas fijas y publicadas" where EN says "flat published fees"; Spanish uses *tarifa* for both fee and fare, so it reads as **fixed fares** on a metered service, and §5's pattern misses it. Pre-existing from #37, **blocks #42**. And #76, the site-wide contrast measurement.

**Re-verified:** full build green (0 errors / 0 warnings, no new allowances); **five controls** on the extended `#56` check — production passes, unserved default fails, missing label fails, renamed constant **fails closed**, unreachable endpoint skips; copy re-checked character-for-character in both languages.
