### PR TITLE
Utility pages: /contact (no form), /404 and /redirect bilingual (wayfinder #39)

### DIFF
--- a/.claude/agents/page-consistency.md
+++ b/.claude/agents/page-consistency.md
@@ -9,39 +9,67 @@ files. You report findings and stop.
 
 ## Why this agent exists
 
-The five pages in `src/pages/` disagree with each other. There is no shared
-layout enforcing a shape, no linter, and no test. Structural drift is invisible
-until it renders wrong in production.
+There is one layout and one page shape, and nothing enforces it: no linter, no
+test, and `astro check` only sees types. Structural drift is invisible until it
+renders wrong in production.
+
+This checklist described the **pre-#35** site until wayfinder #39, and was
+inverted on almost every item — it asked for the Tailwind CDN tag, the Inter
+Google Fonts link, per-page `<head>` blocks and inlined header markup, all of
+which #35 deleted, and it forbade `BaseLayout`, which every page now uses. If a
+page still matches the old checklist, that page is the finding.
 
 ## Reference shape
 
-`src/pages/fare-estimate.astro` is the post-migration model. Compare against it,
-not against whichever page the author copied.
+`src/pages/riders.astro` and `src/pages/es/riders.astro` are the model. Compare
+against them, not against whichever page the author copied.
+
+A page file is **thin**: `BaseLayout` plus one body component, nothing else.
 
 ## Checklist
 
 Read the target page, then check each item and report PASS or FAIL with the
 offending line.
 
-1. **No Tailwind CDN.** `<script src="https://cdn.tailwindcss.com">` must be
-   absent — `@astrojs/tailwind` already supplies Tailwind. Four legacy pages
-   still have it; a new page having it is a finding.
-2. **Header and Footer imported and rendered.** `Header.astro` and
-   `Footer.astro` imported in frontmatter and present in `<body>`. Note if the
-   page inlines its own header/footer markup instead (only `index.astro` is
-   expected to).
-3. **No `BaseLayout.astro`.** Only `404.astro` should use it.
-4. **Head block complete**: `charset`, `favicon.svg` icon link, `viewport`,
-   `Astro.generator`, and a `<title>` ending in `- YeRide`.
-5. **Inter font linked** via the Google Fonts stylesheet.
-6. **`<body>` classes** match `bg-gray-50 text-gray-900 font-sans`.
-7. **`<main>` clears the fixed header** with `pt-[90px]`.
+1. **Renders through `BaseLayout`.** Imported in frontmatter and wrapping the
+   whole body. No page declares `<html>`, `<head>`, `<title>`, `<meta>`,
+   favicons, fonts or canonical/hreflang links of its own — `BaseLayout` owns all
+   of it.
+2. **No inline header or footer markup**, and no import of `Header.astro` or
+   `Footer.astro`. Those have one caller each, `BaseLayout`.
+3. **Thin page file.** Body content lives in one component under
+   `src/components/`, not in the page. The exception is `about.astro`, which
+   still carries its pre-redesign body pending #85 — flag it as known, not as a
+   new finding.
+4. **Copy lives in `src/i18n/`,** not in the component and not in the page. The
+   body component takes `lang` alone and resolves its own copy; a page that
+   passes resolved copy down as a prop is a finding.
+5. **`title` and `description`** are on the page file (not the component) and
+   match `docs/copy-map.md` §4 **character for character**. The old
+   `"... - YeRide"` form is stale; §4 uses `"... | YeRide"`. `about.astro` and
+   its title are #85's, as above.
+6. **EN/ES twin exists** at the mirrored path with **English slugs** —
+   `/example` → `/es/example`, never `/es/ejemplo`. Missing twins must sit in
+   `PENDING` in `scripts/check-route-parity.mjs` naming the ticket that retires
+   them. `404` and `redirect` are exempt by name: single file, both languages,
+   `bilingual` mode.
+7. **No CDN Tailwind and no Google Fonts link.** `cdn.tailwindcss.com` and
+   `fonts.googleapis.com` must both be absent — Tailwind comes from
+   `@astrojs/tailwind` with the brand preset, Nunito is self-hosted and imported
+   once in `BaseLayout` as `font-brand`. Either one is duplicate CSS and a flash
+   of unstyled content.
 8. **Scripts**: a `<script>` using `import` must NOT be `is:inline`; an
-   `is:inline` script must receive values via `define:vars`.
-9. **No `@apply`** in any `<style>` block — this repo forbids it.
-10. **Nav reachability**: if this is a new route, check whether it appears in
-    `Header.astro`, `Footer.astro`, and both inline copies in `index.astro`.
-    Report each missing surface separately.
+   `is:inline` script cannot use imports and needs `define:vars` for values.
+   Astro does not evaluate expressions inside `<script>`/`<style>` bodies, so a
+   `` {`…`} `` wrapper there ships as literal text — check for it, it fails
+   silently and passes every gate (#39).
+9. **No `@apply`** in any `<style>` block — this repo forbids it. Utility
+   classes directly, mobile-first (`sm`, `md`, `lg`).
+10. **No hard-coded fee or fare amounts** anywhere in the page or its copy
+    (copy-map §0.4). Money is fetched at runtime.
+11. **Nav reachability**: if this is a new route, check whether it appears in
+    `Header.astro` and `Footer.astro` — those two surfaces only; there are no
+    inline copies. Report each missing surface separately.
 
 ## Output
 
@@ -49,6 +77,5 @@ A markdown table: `Check | Verdict | Evidence (file:line)`. Then a short
 `Must fix` list of FAILs only, ordered by user-visible impact. If everything
 passes, say so in one line and add nothing else.
 
-Do not report on styling taste, copy, accessibility, or anything outside the
-checklist. Do not suggest refactoring the legacy pages — they are known and
-intentional until someone schedules that work.
+Do not report on styling taste, copy wording, accessibility, or anything outside
+the checklist.

--- a/.claude/agents/page-consistency.md
+++ b/.claude/agents/page-consistency.md
@@ -43,7 +43,9 @@ offending line.
    new finding.
 4. **Copy lives in `src/i18n/`,** not in the component and not in the page. The
    body component takes `lang` alone and resolves its own copy; a page that
-   passes resolved copy down as a prop is a finding.
+   passes resolved copy down as a prop is a finding. `NotFoundPage` and
+   `RedirectPage` take **no** props — they render both languages at once — and
+   that is the only exception.
 5. **`title` and `description`** are on the page file (not the component) and
    match `docs/copy-map.md` §4 **character for character**. The old
    `"... - YeRide"` form is stale; §4 uses `"... | YeRide"`. `about.astro` and

--- a/.claude/skills/nav-sync/SKILL.md
+++ b/.claude/skills/nav-sync/SKILL.md
@@ -5,28 +5,61 @@ description: Use when adding, removing, renaming, or re-pointing any navigation 
 
 # nav-sync
 
-Navigation markup is duplicated across four independent copies. A link must be
-added to all four, or it appears on some pages and not others.
+Navigation is **not** duplicated. `Header.astro` and `Footer.astro` have exactly
+one caller each — `BaseLayout.astro` — and every page renders through it
+(wayfinder #35). A nav or footer change is one edit, in one file.
 
-| Surface | File | Reaches |
+This skill described four duplicated copies until #39. The inline header and
+footer in `index.astro`, `navBar.astro` and `src/data/navData.ts` were all
+deleted by #35; none of them exist. If you are looking for a second copy to keep
+in sync, there isn't one.
+
+| Surface | File | Links today |
 |---|---|---|
-| Shared header | `src/components/Header.astro` | about, contact, privacy-policy, fare-estimate |
-| Shared footer | `src/components/Footer.astro` | same four pages |
-| Inline header | `src/pages/index.astro` (~95–130) | homepage only |
-| Inline footer | `src/pages/index.astro` (~345–395) | homepage only |
+| Header | `src/components/Header.astro` | `/drivers`, `/riders`, `/fees`, `/fare-estimate`, then the EN⇄ES toggle |
+| Footer | `src/components/Footer.astro` | `/about`, `/contact`, `/privacy-policy`, `/terms`, plus the X link |
 
-`src/components/navBar.astro` + `src/data/navData.ts` are a fifth, near-dead copy
-reached only by `BaseLayout.astro` → `404.astro`. Its entries (`ride`, `drive`,
-`register`) point at routes that do not exist.
+Both are rendered by `BaseLayout` on every page, so both reach the whole site.
 
-`BaseLayout.astro` renders `<Nav />` + `<slot />` and **no footer at all**, so
-`404.astro` has no footer to add a link to. Full-site footer coverage there is a
-structural change (import and render `Footer.astro`), not a link edit — treat it
-as out of scope unless asked.
+## Adding a link
 
-Inventory every surface before and after the change — the two lists must match:
+Each file holds a `t` object keyed `en`/`es` for the labels and builds every
+href as `` `${esPrefix}/route` ``, where `esPrefix` is `/es` when `lang === "es"`.
+So a link is **one href plus two labels** — you never write the Spanish URL, and
+an EN entry cannot ship without its ES twin.
+
+Labels are copy. Take them from `docs/copy-map.md` §1.1 (header) and §1.2
+(footer) rather than authoring them here.
+
+Order is fixed in the header — audience pages, then the two proof pages, then
+the toggle (§1.1). Don't reorder it to fit a new entry.
+
+## What the build enforces
+
+- **The route must exist in both languages.** `scripts/check-route-parity.mjs`
+  fails on an English page with no `/es/` twin, so linking a route that only
+  half-exists fails the build rather than 404ing in one language.
+- **Labels go through the copy gate** like any other string
+  (`scripts/check-copy-gate.mjs`, copy-map §5).
+
+## Two things that are not files under `src/pages`
+
+- **Redirect aliases** live in `astro.config.mjs` (`/privacy`, `/es/privacy`,
+  `/support`). They are routes a visitor can reach and the mobile app depends on
+  them (#44), but the parity check does not see them — it reads filenames. If you
+  add an alias, add its `/es/` counterpart in the same edit.
+- **`/404` and `/redirect`** are single files serving both languages
+  (`bilingual` mode, #39). In `bilingual` mode `BaseLayout` renders *two* copies
+  of the header and footer, one per language, and reveals one client-side — so
+  these pages do have a footer, and your one edit reaches both copies.
+
+## Check your work
+
+Both hrefs and both label sets, before and after:
 
 ```bash
 grep -n 'href=' src/components/Header.astro src/components/Footer.astro
-grep -n 'href="/\|href="#' src/pages/index.astro
+grep -n 'about:\|contact:\|privacy:\|terms:\|drivers:\|riders:\|fees:\|estimate:' \
+  src/components/Header.astro src/components/Footer.astro
+npm run checks
 ```

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -51,8 +51,10 @@ Model it on `RidersPage.astro` + `audienceCopy.ts`, or `FeeSchedule.astro` +
 
 `BaseLayout` props: `title`, `description`, `lang`, `headerGround`
 (`"paper" | "yellow" | "ink"` — the ground the header sits on, so it picks the
-legible mark), and `alternates` (leave default; `false` only for `/404` and
-`/redirect`, which are single-file by design).
+legible mark), `alternates` (leave default; `false` only for `/404` and
+`/redirect`, which are single-file by design), and `bilingual` (leave default —
+those same two pages, and no others, ship both languages of the chrome and
+reveal one client-side; see `docs/components.md` under `BaseLayout`).
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,11 @@ and bury your real change in a full-file diff.
 - **Tally.so** — embedded contact form, **one per language**, mapped in
   `src/components/ContactPage.astro` (`/contact` is `mJa5J7`). Tally has no runtime
   localisation and copy-map §3.7 requires the Spanish questions authored rather than
-  translated, so `/es/contact` embeds its own form; an id that is unset, or that falls back to
-  the English one, throws at build time rather than shipping a healthy-looking form in the
-  wrong language
+  translated, so `/es/contact` will embed its own form once it exists (it does not yet —
+  copy-map §6.5). Three build-time throws guard it: the **route** must agree with the `lang`
+  prop (keying on `lang` alone let an `/es/` page render `lang="en"` and ship the English form
+  off a green build), the id must be shaped like a Tally id, and no two languages may share
+  one. None of them can catch a well-formed id that is simply the wrong form
 - **Nunito** — the brand typeface, self-hosted via `@fontsource-variable/nunito` and imported once in `BaseLayout`; exposed as `font-brand`. The old per-page Google Fonts link to Inter is gone (#35)
 - `src/pages/redirect.astro` — bounces to the `yeride://register` deep link. Not bare HTML:
   it renders through `BaseLayout` like everything else (#35), in `bilingual` mode (#39)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,14 +95,14 @@ and bury your real change in a full-file diff.
 
 ### Other integrations
 
-- **Tally.so** — embedded contact form, **one per language**, mapped in
-  `src/components/ContactPage.astro` (`/contact` is `mJa5J7`). Tally has no runtime
-  localisation and copy-map §3.7 requires the Spanish questions authored rather than
-  translated, so `/es/contact` will embed its own form once it exists (it does not yet —
-  copy-map §6.5). Three build-time throws guard it: the **route** must agree with the `lang`
-  prop (keying on `lang` alone let an `/es/` page render `lang="en"` and ship the English form
-  off a green build), the id must be shaped like a Tally id, and no two languages may share
-  one. None of them can catch a well-formed id that is simply the wrong form
+- **No contact form, and no Tally** — `/contact` publishes `support@yeride.com` and nothing
+  else (#39 amended copy-map §3.7). The embedded Tally form was dropped: its questions lived
+  inside Tally, the last user-facing copy on this site outside the repo and invisible to both
+  copy gates, and Tally has no runtime localisation, so `/es/contact` would have needed a
+  second form authored and kept in sync by hand forever. Removing it also deleted a named
+  processor from the privacy policy. **Do not re-add a third-party form embed.** If
+  structured intake is wanted, copy `PreRegistrationForm.astro` — markup and per-field EN/ES
+  copy in `src/i18n/`, posting to an endpoint YeRide owns
 - **Nunito** — the brand typeface, self-hosted via `@fontsource-variable/nunito` and imported once in `BaseLayout`; exposed as `font-brand`. The old per-page Google Fonts link to Inter is gone (#35)
 - `src/pages/redirect.astro` — bounces to the `yeride://register` deep link. Not bare HTML:
   it renders through `BaseLayout` like everything else (#35), in `bilingual` mode (#39)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,18 @@ or footer change is therefore one edit, in one place.
 
 Redesigned routes keep the page file thin — `BaseLayout` plus one component that holds the
 whole body (`HomePage`, `DriversPage`, `RidersPage`, `FeeSchedule`, `FareEstimatePage`) — with
-the copy in `src/i18n/`. Follow that shape when adding a page. The pages still awaiting
-their redesign ticket (`about`, `contact`) sit on `BaseLayout` with their
-pre-redesign bodies inline.
+the copy in `src/i18n/`. Follow that shape when adding a page. One page still awaits its
+redesign ticket — `about` — and sits on `BaseLayout` with its pre-redesign body inline; it is
+[#85](https://github.com/yeapptech/yeride-website/issues/85), blocked outside this repo on
+yeapptech/yeride-brand#22's authored ES identity paragraph.
+
+`/404` and `/redirect` are the two exceptions to "every route ships EN and ES": they are one
+file each, serving **both** languages, because GitHub Pages answers every missing path with a
+single root `404.html` and `/es/404` is therefore unreachable. `BaseLayout`'s `bilingual`
+prop ships both languages of the header and footer alongside the page's own two halves and
+reveals one from `location.pathname` — chrome included, since Spanish content under English
+navigation is the half-translated page #62 and #65 were re-opened over. The mechanism, and
+the two ways it fails silently, are in `docs/components.md` under `BaseLayout`.
 
 `navBar.astro`, `src/data/navData.ts`, `src/styles/main.css` (Open Props from unpkg) and the
 `https://cdn.tailwindcss.com` script tags were all removed by #35. Tailwind comes from the
@@ -86,9 +95,15 @@ and bury your real change in a full-file diff.
 
 ### Other integrations
 
-- **Tally.so** — embedded contact form on `/contact` (form ID `mJa5J7`)
+- **Tally.so** — embedded contact form, **one per language**, mapped in
+  `src/components/ContactPage.astro` (`/contact` is `mJa5J7`). Tally has no runtime
+  localisation and copy-map §3.7 requires the Spanish questions authored rather than
+  translated, so `/es/contact` embeds its own form; an id that is unset, or that falls back to
+  the English one, throws at build time rather than shipping a healthy-looking form in the
+  wrong language
 - **Nunito** — the brand typeface, self-hosted via `@fontsource-variable/nunito` and imported once in `BaseLayout`; exposed as `font-brand`. The old per-page Google Fonts link to Inter is gone (#35)
-- `src/pages/redirect.astro` — bare HTML that bounces to the `yeride://register` deep link
+- `src/pages/redirect.astro` — bounces to the `yeride://register` deep link. Not bare HTML:
+  it renders through `BaseLayout` like everything else (#35), in `bilingual` mode (#39)
 - **URL aliases the mobile app depends on** — `redirects` in `astro.config.mjs` maps `/privacy`
   → `/privacy-policy`, `/es/privacy` → `/es/privacy-policy` and `/support` → `/contact`
   (wayfinder #44). These are not cosmetic: yeride-mobile links `yeride.com/privacy` in-app and

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,11 +21,14 @@ export default defineConfig({
   // than as files under src/pages so #41's route-parity check — which reads
   // src/pages filenames — is not asked to find an /es/ twin for an alias.
   //
-  // There is no /es/support: its target, /es/contact, does not exist yet (#39).
+  // /es/support joins them now that /es/contact exists (#39). The route-parity
+  // check fails the build the moment src/pages/es/contact.astro is present
+  // without it, so this pair cannot drift apart.
   redirects: {
     "/privacy": "/privacy-policy",
     "/es/privacy": "/es/privacy-policy",
     "/support": "/contact",
+    "/es/support": "/es/contact",
   },
   //output: "server",
   // adapter: node({

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,8 @@ yeride-website/
 │   │   ├── FareEstimatePage.astro  # /fare-estimate — Maps + estimateFares
 │   │   ├── LegalDocument.astro     # /privacy-policy and /terms, both languages
 │   │   ├── ContactPage.astro
+│   │   ├── NotFoundPage.astro      # /404 — renders EN and ES at once
+│   │   ├── RedirectPage.astro      # /redirect — same
 │   │   ├── AvailabilityBlock.astro # Shared block (copy-map §2.1)
 │   │   └── PreRegistrationForm.astro
 │   │
@@ -153,7 +155,8 @@ picks the mark that is legal on that ground, and `alternates`/`bilingual` are fo
 3. **Body components** — one per route (`HomePage`, `DriversPage`, `RidersPage`,
    `FeeSchedule`, `FareEstimatePage`, `LegalDocument`, `ContactPage`). Each takes
    `lang` **alone** and resolves its own copy from `src/i18n/`. A page that
-   passes resolved copy down as a prop breaks the contract.
+   passes resolved copy down as a prop breaks the contract. `NotFoundPage` and
+   `RedirectPage` take no props at all — they render both languages at once.
 4. **Shared blocks** — `AvailabilityBlock`, `PreRegistrationForm`, used by more
    than one body component.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,129 +9,204 @@ This document describes the technical architecture of the YeRide website.
 | [Astro](https://astro.build) 5.x | Static site generator |
 | [TypeScript](https://www.typescriptlang.org) 5.x | Type safety |
 | [Tailwind CSS](https://tailwindcss.com) 3.x | Utility-first styling |
-| [Firebase](https://firebase.google.com) 11.x | Backend services |
+| [Firebase](https://firebase.google.com) 11.x | `firebase/functions` **only** — one callable, `estimateFares`. Auth and Firestore are not used |
+| `@yeapptech/yeride-brand` | The design system: Tailwind preset, tokens, marks. Private package; binding docs live in its repo |
 
 ## Directory Structure
 
 ```
 yeride-website/
 ├── src/
-│   ├── components/           # Reusable Astro components
-│   │   ├── Header.astro      # Navigation header with mobile menu
-│   │   ├── Footer.astro      # Site footer
-│   │   ├── navBar.astro      # Navigation bar
-│   │   └── PreRegistrationForm.astro  # User registration form
+│   ├── components/           # One body component per route, plus the chrome
+│   │   ├── Header.astro      # Site header — one caller, BaseLayout
+│   │   ├── Footer.astro      # Site footer — one caller, BaseLayout
+│   │   ├── HomePage.astro    # The whole body of / and /es/
+│   │   ├── DriversPage.astro
+│   │   ├── RidersPage.astro
+│   │   ├── FeeSchedule.astro       # /fees — fetches the live rate card
+│   │   ├── FareEstimatePage.astro  # /fare-estimate — Maps + estimateFares
+│   │   ├── LegalDocument.astro     # /privacy-policy and /terms, both languages
+│   │   ├── ContactPage.astro
+│   │   ├── AvailabilityBlock.astro # Shared block (copy-map §2.1)
+│   │   └── PreRegistrationForm.astro
+│   │
+│   ├── i18n/                 # ALL copy, EN/ES, verbatim from docs/copy-map.md
+│   │   ├── homeCopy.ts  audienceCopy.ts  feesCopy.ts
+│   │   ├── fareEstimateCopy.ts  legalCopy.ts  utilityCopy.ts
+│   │   ├── formCopy.ts
+│   │   └── feeLabels.ts      # Site-authored names for backend charge/area/tier ids
+│   │
+│   ├── lib/
+│   │   ├── firebase.ts       # firebase/functions only — no Auth, no Firestore
+│   │   ├── fareEstimate.ts   # estimateFares callable + its rider-facing contract
+│   │   ├── feeSchedule.ts    # getFeeSchedule fetch + response contract
+│   │   └── serviceArea.ts    # The one service-area constant /fare-estimate prices for
 │   │
 │   ├── layouts/
-│   │   └── BaseLayout.astro  # Base page layout template
+│   │   └── BaseLayout.astro  # The ONLY layout. Every page renders through it
 │   │
-│   ├── pages/                # File-based routing
-│   │   ├── index.astro       # Homepage
-│   │   ├── about.astro       # About page
-│   │   ├── contact.astro     # Contact page
-│   │   ├── privacy-policy.astro  # Privacy policy
-│   │   └── 404.astro         # Error page
-│   │
-│   ├── data/
-│   │   └── navData.ts        # Navigation menu configuration
-│   │
-│   └── styles/
-│       └── main.css          # Global styles
+│   └── pages/                # File-based routing — thin files, EN + /es/ twin
+│       ├── index.astro  drivers.astro  riders.astro  fees.astro
+│       ├── fare-estimate.astro  about.astro  contact.astro
+│       ├── privacy-policy.astro  terms.astro
+│       ├── 404.astro         # Both languages, one file
+│       ├── redirect.astro    # Both languages, one file
+│       └── es/               # The mirrored tree, English slugs
 │
 ├── public/                   # Static assets
-│   ├── favicon.svg           # Site favicon
 │   ├── CNAME                 # Custom domain configuration
 │   ├── .nojekyll             # Disable Jekyll on GitHub Pages
 │   └── images/               # Image assets
 │
+├── scripts/                  # The build gates — see CLAUDE.md
+│   ├── check-route-parity.mjs      check-copy-gate.mjs
+│   ├── check-env.mjs               check-dist-copy-gate.mjs
+│   ├── check-fee-labels.mjs        # Runs outside npm run build (needs network)
+│   ├── copy-gate-patterns.mjs      copy-gate-normalise.mjs
+│   └── copy-gate-patterns.test.mjs # Run by hand when the pattern list changes
+│
 ├── .github/
 │   └── workflows/
-│       └── deploy-all.yml    # CI/CD workflow
+│       ├── checks.yml        # Route parity + copy gate, every PR, no deps
+│       ├── deploy-all.yml    # Full chain + deploy, on main
+│       └── fee-label-drift.yml     # Daily fee-label check
 │
 └── Configuration files
-    ├── astro.config.mjs      # Astro configuration
-    ├── tailwind.config.mjs   # Tailwind configuration
+    ├── astro.config.mjs      # Astro configuration + the mobile-app redirects
+    ├── tailwind.config.mjs   # Brand preset
     ├── tsconfig.json         # TypeScript configuration
     └── package.json          # Dependencies and scripts
 ```
 
+Favicons and fonts are not in `public/` — they come from the
+`@yeapptech/yeride-brand` package and are imported in `BaseLayout`.
+
 ## Routing
 
-Astro uses **file-based routing**. Each `.astro` file in `src/pages/` becomes a route:
+Astro uses **file-based routing**. Each `.astro` file in `src/pages/` becomes a
+route, and **every route ships in both languages** — the `/es/` tree mirrors the
+English one with **English slugs** (`/fees` → `/es/fees`, never `/es/tarifas`).
+`scripts/check-route-parity.mjs` fails the build on a missing twin.
 
-| File | Route |
-|------|-------|
-| `src/pages/index.astro` | `/` |
-| `src/pages/about.astro` | `/about` |
-| `src/pages/contact.astro` | `/contact` |
-| `src/pages/privacy-policy.astro` | `/privacy-policy` |
-| `src/pages/404.astro` | `/404` (error page) |
+| File | Route | ES twin |
+|------|-------|---------|
+| `src/pages/index.astro` | `/` | `/es/` |
+| `src/pages/drivers.astro` | `/drivers` | `/es/drivers` |
+| `src/pages/riders.astro` | `/riders` | `/es/riders` |
+| `src/pages/fees.astro` | `/fees` | `/es/fees` |
+| `src/pages/fare-estimate.astro` | `/fare-estimate` | `/es/fare-estimate` |
+| `src/pages/privacy-policy.astro` | `/privacy-policy` | `/es/privacy-policy` |
+| `src/pages/terms.astro` | `/terms` | `/es/terms` |
+| `src/pages/contact.astro` | `/contact` | pending (#39) |
+| `src/pages/about.astro` | `/about` | pending (#85) |
+| `src/pages/404.astro` | `/404` | **same file** |
+| `src/pages/redirect.astro` | `/redirect` | **same file** |
+
+`/404` and `/redirect` are the two exemptions. GitHub Pages answers every missing
+path with a single root `404.html`, so `/es/404` is unreachable; both pages ship
+**both** languages in one file and reveal one client-side from
+`location.pathname` (`BaseLayout`'s `bilingual` mode). They are exempt from the
+parity check by name.
+
+Three further routes are **redirects declared in `astro.config.mjs`**, not files:
+`/privacy` → `/privacy-policy`, `/es/privacy` → `/es/privacy-policy`, and
+`/support` → `/contact`. The mobile app depends on them — it links
+`yeride.com/privacy` in-app and submits it as the store-listing privacy URL, and
+a missing `/support` was a 2025 App Store rejection. Do not remove or rename
+them without changing the app first.
 
 ## Component Architecture
 
 ### Layout System
 
-The `BaseLayout.astro` component provides the HTML structure shared across pages:
+`BaseLayout.astro` is the **only** layout, and it owns everything above the page
+content: `<html>`, `<head>`, the title and meta description, the canonical link,
+the EN/ES `hreflang` alternates, the brand favicons, the Nunito import, and the
+header and footer. **No page declares any of it.**
 
 ```astro
 ---
-// BaseLayout.astro
-const { title } = Astro.props;
+// src/pages/riders.astro — the model. Nothing else belongs in a page file.
+import BaseLayout from "../layouts/BaseLayout.astro";
+import RidersPage from "../components/RidersPage.astro";
 ---
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>{title}</title>
-  </head>
-  <body>
-    <Header />
-    <slot />  <!-- Page content inserted here -->
-    <Footer />
-  </body>
-</html>
+
+<BaseLayout
+  title="Pay what the ride is worth. | YeRide for riders"
+  description="Published rates — base, miles, minutes. The same math every trip, and every fee published. Card or cash."
+  lang="en"
+  headerGround="yellow"
+>
+  <RidersPage lang="en" />
+</BaseLayout>
 ```
+
+Its props are documented in [components.md](./components.md); `headerGround`
+picks the mark that is legal on that ground, and `alternates`/`bilingual` are for
+`/404` and `/redirect` alone.
 
 ### Component Types
 
-1. **Layout Components** - Define page structure (`BaseLayout.astro`)
-2. **UI Components** - Reusable interface elements (`Header`, `Footer`)
-3. **Feature Components** - Complex functionality (`PreRegistrationForm`)
-4. **Page Components** - Route-specific content (`index.astro`, `about.astro`)
+1. **The layout** — `BaseLayout.astro`. There is one.
+2. **Chrome** — `Header`, `Footer`. One caller each, `BaseLayout`; a nav change
+   is one edit.
+3. **Body components** — one per route (`HomePage`, `DriversPage`, `RidersPage`,
+   `FeeSchedule`, `FareEstimatePage`, `LegalDocument`, `ContactPage`). Each takes
+   `lang` **alone** and resolves its own copy from `src/i18n/`. A page that
+   passes resolved copy down as a prop breaks the contract.
+4. **Shared blocks** — `AvailabilityBlock`, `PreRegistrationForm`, used by more
+   than one body component.
 
 ## Styling Approach
 
 ### Tailwind CSS
 
-The project uses Tailwind CSS for styling with utility classes:
+Utility classes directly, mobile-first. **Never `@apply`.** Colour, type and
+spacing come from the brand preset, so the tokens are the vocabulary —
+`bg-paper`, `text-ink`, `bg-cab-yellow`, `font-brand`, `tracking-headline`,
+`tracking-caps` — not raw greys:
 
 ```astro
-<div class="flex items-center justify-between p-4 bg-white shadow-md">
-  <h1 class="text-2xl font-bold text-gray-900">YeRide</h1>
+<div class="mx-auto w-full max-w-3xl px-5 py-16 sm:px-6">
+  <h1 class="font-extrabold tracking-headline text-[2rem] text-ink sm:text-[2.5rem]">
+    Pay what the ride is worth.
+  </h1>
 </div>
 ```
 
 ### Global Styles
 
-Global styles are defined in `src/styles/main.css`:
+There is no global stylesheet. `src/styles/main.css` and its Open Props import
+were deleted in wayfinder #35, along with the `cdn.tailwindcss.com` script tags
+and the Google Fonts link to Inter — **do not re-add any of them**; each is
+duplicate CSS and a flash of unstyled content.
 
-```css
-@import "open-props/style";
-/* Additional global styles */
+What `BaseLayout` imports once, for the whole site:
+
+```astro
+import "@fontsource-variable/nunito";        // the brand typeface, self-hosted
+import "@yeapptech/yeride-brand/tokens.css";  // the brand's CSS custom properties
 ```
 
 ### Configuration
 
-Tailwind is configured in `tailwind.config.mjs`:
+Tailwind takes its theme from the brand package's preset — this repo defines no
+colours or type scale of its own:
 
 ```javascript
+import brandPreset from '@yeapptech/yeride-brand/tailwind-preset';
+
 export default {
-  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,ts,tsx}'],
-  theme: {
-    extend: {},
-  },
+  presets: [brandPreset],
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  theme: { extend: {} },
   plugins: [],
 }
 ```
+
+`@yeapptech/yeride-brand` is a **private package** on GitHub Packages. Installing
+needs the committed `.npmrc` plus an `NPM_TOKEN` (a classic PAT with
+`read:packages`); CI reads it from an Actions secret.
 
 ## Data Flow
 
@@ -141,11 +216,25 @@ Astro generates static HTML at build time. The site has no server-side rendering
 
 ### API Integration
 
-The pre-registration form submits data to an external API:
+The site talks to **two unrelated backends** — yeride-admin-api and
+yeride-functions — across three flows. Don't conflate the first with the others:
 
 ```
-User Input → PreRegistrationForm → POST /v1/auth/register → API Response
+Pre-registration   PreRegistrationForm → POST ${PUBLIC_API_URL}v1/auth/register
+                   → yeride-admin-api. Writes a `whitelist` row; creates no account.
+
+Fare estimates     FareEstimatePage → Google Maps (maps, places, marker, routes)
+                   → Firebase callable `estimateFares` (us-east1) → yeride-functions
+
+Fee schedule       FeeSchedule → GET ${PUBLIC_FEE_SCHEDULE_URL}
+                   → yeride-functions. Plain fetch, no Firebase SDK.
 ```
+
+Two contracts are written into `src/lib/` and should be read before changing
+either page: `fareEstimate.ts` records why `ServiceEstimate` deliberately does
+**not** declare `appCharges`/`appChargesTotal` (they are the *driver's* cost in
+both payment flows, never the rider's), and `feeSchedule.ts` records that the
+site is **never a third evaluator** of the backend's charge expressions.
 
 See [API Integration](./api-integration.md) for details.
 
@@ -161,10 +250,28 @@ All six are required; `npm run build` fails on a missing one. The full list is i
 
 ## Build Process
 
-1. **Type Checking** - TypeScript validation via `astro check`
-2. **Asset Processing** - Tailwind CSS compilation
-3. **Static Generation** - HTML pages generated from Astro components
-4. **Output** - Static files written to `./dist/`
+There is no test runner and no linter. **`npm run build` is the verification
+gate**, and it runs five things in order — any one of them fails the build:
+
+1. **Route parity** (`check-route-parity.mjs`) — every route has its `/es/` twin.
+2. **Copy gate** (`check-copy-gate.mjs`) — gated and never-claimed strings
+   (copy-map §5) must not reach `src/` or `public/`.
+3. **Env check** (`check-env.mjs`) — all six `PUBLIC_*` present, non-empty and
+   printable ASCII. Astro inlines them at build time, so an empty one becomes a
+   falsy literal and Rollup deletes the branch that tested it.
+4. **`astro check`** — a type error fails the build.
+5. **Dist copy gate** (`check-dist-copy-gate.mjs`) — §5 again, over `dist/`,
+   after `astro build`. This is the layer that measures the actual promise.
+
+Items 1–2 are dependency-free and run on every PR (`checks.yml`); 3–5 need
+`npm ci` against the private registry and run on `main` (`deploy-all.yml`).
+
+A sixth gate, **`check-fee-labels.mjs`**, runs *outside* the build because it
+needs the network: it asks the live `getFeeSchedule` whether the site can name
+every charge, service-area and ride-tier id it publishes. It fails on drift and
+**skips** when it cannot ask. Deploy-time plus daily on a schedule.
+
+Full detail for each is in CLAUDE.md.
 
 ## Configuration Files
 
@@ -176,7 +283,14 @@ import tailwind from '@astrojs/tailwind';
 
 export default defineConfig({
   integrations: [tailwind()],
-  site: 'https://yeride.com',
+  // must match public/CNAME — canonical and hreflang URLs derive from it
+  site: 'https://www.yeride.com',
+  // routes the MOBILE APP promises; see Routing above before touching these
+  redirects: {
+    '/privacy': '/privacy-policy',
+    '/es/privacy': '/es/privacy-policy',
+    '/support': '/contact',
+  },
 });
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ English one with **English slugs** (`/fees` → `/es/fees`, never `/es/tarifas`)
 | `src/pages/fare-estimate.astro` | `/fare-estimate` | `/es/fare-estimate` |
 | `src/pages/privacy-policy.astro` | `/privacy-policy` | `/es/privacy-policy` |
 | `src/pages/terms.astro` | `/terms` | `/es/terms` |
-| `src/pages/contact.astro` | `/contact` | pending (#39) |
+| `src/pages/contact.astro` | `/contact` | `/es/contact` |
 | `src/pages/about.astro` | `/about` | pending (#85) |
 | `src/pages/404.astro` | `/404` | **same file** |
 | `src/pages/redirect.astro` | `/redirect` | **same file** |
@@ -110,9 +110,9 @@ path with a single root `404.html`, so `/es/404` is unreachable; both pages ship
 `location.pathname` (`BaseLayout`'s `bilingual` mode). They are exempt from the
 parity check by name.
 
-Three further routes are **redirects declared in `astro.config.mjs`**, not files:
-`/privacy` → `/privacy-policy`, `/es/privacy` → `/es/privacy-policy`, and
-`/support` → `/contact`. The mobile app depends on them — it links
+Four further routes are **redirects declared in `astro.config.mjs`**, not files:
+`/privacy` → `/privacy-policy`, `/es/privacy` → `/es/privacy-policy`,
+`/support` → `/contact` and `/es/support` → `/es/contact`. The mobile app depends on them — it links
 `yeride.com/privacy` in-app and submits it as the store-listing privacy URL, and
 a missing `/support` was a 2025 App Store rejection. Do not remove or rename
 them without changing the app first.
@@ -293,6 +293,7 @@ export default defineConfig({
     '/privacy': '/privacy-policy',
     '/es/privacy': '/es/privacy-policy',
     '/support': '/contact',
+    '/es/support': '/es/contact',
   },
 });
 ```

--- a/docs/components.md
+++ b/docs/components.md
@@ -427,48 +427,47 @@ wrong language out of view regardless.
 
 ### ContactPage
 
-The body of `/contact` (wayfinder #39). `/es/contact` **does not exist yet** — it is blocked
-on a Spanish Tally form that has not been created (copy-map §6.5), and `scripts/check-route-parity.mjs`
-carries `contact` in `PENDING` until it does.
+The body of `/contact` and `/es/contact` (wayfinder #39).
 
 **Location:** `src/components/ContactPage.astro`
 
 **Props:**
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
-| `lang` | `"en" \| "es"` | **yes** | Selects the copy and the Tally form |
+| `lang` | `"en" \| "es"` | **yes** | Selects the copy |
 
 Copy: `src/i18n/utilityCopy.ts` (`contactCopy`), verbatim from copy-map §3.7. Takes `lang`
 alone and resolves its own copy, the contract every page component here follows.
 
-**This page is load-bearing beyond its own content.** `/support` redirects here
-(`astro.config.mjs`, wayfinder #44), and that is the URL yeride-mobile submits to the app
-stores as its support contact — a missing one was a 2025 App Store rejection. The address on
-it was `support@yeride.app`, which nobody reads; §3.7 corrects it to `support@yeride.com`,
-and it is a `mailto:` link rather than plain text for the same reason `LegalDocument`
-linkifies it: it is the only action the page offers besides the form.
+**This page is load-bearing beyond its own content.** `/support` redirects here and
+`/es/support` to its twin (`astro.config.mjs`, wayfinder #44), and that is the URL
+yeride-mobile submits to the app stores as its support contact — a missing one was a 2025
+App Store rejection. The address on it was `support@yeride.app`, which nobody reads; §3.7
+corrects it to `support@yeride.com`, and it is a `mailto:` link rather than plain text
+because it is the only action the page offers.
 
-**Two Tally forms, not one.** `TALLY_FORM_ID` maps language → form id. Tally has no runtime
-localisation and §3.7 requires the Spanish questions to be **authored**, not translated, so
-`/es/contact` will embed its own form; embedding the English `mJa5J7` under Spanish chrome is
-the half-translated page #65 was re-opened over.
+**There is no form, and that is a decision — do not re-add a third-party embed.** The page
+carried an embedded Tally form until #39 amended §3.7 to drop it. Three things settled it:
 
-Three build-time throws guard it, because the failure is silent by nature — a wrong-language
-form looks perfectly healthy:
+- The form's **questions lived inside Tally** — the last user-facing copy on this site
+  outside the repo, invisible to the copy map and to both copy gates. §3.7 had no cells for
+  them at all, where §2.2 specifies every label and placeholder of the pre-registration form
+  in both languages.
+- **Tally has no runtime localisation**, so `/es/contact` needed a *second* form, authored
+  in Spanish and kept in sync by hand forever. That blocked the page in both languages under
+  §0.1, and an English form under Spanish chrome is the half-translated page #65 was
+  re-opened over.
+- Removing it **deleted a named processor** from a privacy policy held for legal sign-off —
+  a simpler edit than swapping one vendor for another, which is why a Formspree-class
+  replacement was rejected too: it keeps a processor and buys only what an owned endpoint
+  would.
 
-1. **The route must agree with `lang`.** This one an independent review had to teach the
-   file: the first version keyed only on the `lang` prop, and nothing ties an `/es/` route
-   to `lang="es"`. Measured — `src/pages/es/contact.astro` rendering `<ContactPage lang="en" />`
-   built **green** and shipped the English form under Spanish chrome, the exact failure the
-   guard claimed to prevent. Route-parity only checks that a *file* exists, so the route is
-   the fact worth checking.
-2. **The id must be shaped like a Tally id** (`/^[A-Za-z0-9]{4,12}$/`). Absent, still the
-   `"PENDING"` sentinel, or empty all fail — an empty one would embed `tally.so/embed/?…`,
-   a blank panel rather than an error.
-3. **No two languages may share an id.**
+The address was already a live `mailto:` in both legal documents, so publishing it here
+exposed nothing new, and the store requirement is a reachable support **URL**, not a form.
 
-What none of them catch, stated rather than left to be found: a well-formed id that is simply
-the wrong form. Nothing in the build can tell `mJa5J7` from `mJa5J8`.
+If structured intake is wanted later, the shape to copy is **`PreRegistrationForm`** —
+markup and per-field EN/ES copy in `src/i18n/`, posting to an endpoint YeRide owns — with a
+copy-map amendment giving §3.7 the field cells §2.2 has.
 
 ## Page-Specific Components
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -18,6 +18,42 @@ The base layout template for all pages.
 | `lang` | `"en" \| "es"` | no (`"en"`) | Sets `<html lang>` and the chrome's language |
 | `headerGround` | `"paper" \| "yellow" \| "ink"` | no (`"paper"`) | The ground the header sits on, so it merges with the page's first section |
 | `alternates` | `boolean` | no (`true`) | EN/ES `hreflang` pair + `x-default`. Only `/404` and `/redirect` pass `false` — they are single-file by design (copy-map §3.10–§3.11) |
+| `bilingual` | `boolean` | no (`false`) | Ships **both** languages of the header and footer and reveals one client-side. The same two pages that pass `alternates={false}` pass this, and no others (wayfinder #39) |
+
+**`bilingual` mode.** GitHub Pages serves one root `404.html` for every missing path, so a
+Spanish visitor at `/es/anything` lands on the English build of `/404`. Header and footer are
+page copy like everything else, and leaving them English under Spanish content is the
+half-translated page #62 and #65 were re-opened over — so in this mode `BaseLayout` renders
+both and lets the page pick.
+
+The mechanism is a stamp plus a stylesheet, not a DOM rewrite:
+
+- an inline `<head>` script sets `data-lang="es"` on `<html>` when `location.pathname` is
+  `/es` or starts with `/es/`, and fixes `<html lang>` to match. It runs **before the body is
+  parsed**, so the right language is chosen before the first paint — a switch on
+  `DOMContentLoaded` would flash English at every Spanish visitor.
+- an inline `<style>` hides the halves: `html:not([data-lang="es"]) [data-lang="es"]` and
+  `html[data-lang="es"] [data-lang="en"]`. Written as `:not`, so the **default state — no
+  `data-lang`, which is what a visitor with JavaScript off gets — shows English and hides
+  Spanish**, matching copy-map §3.10's "renders English by default".
+
+Both must stay `is:inline`. A scoped `<style>` is keyed to this component's own elements and
+cannot reach through `<slot>` into the page's halves; and Astro does **not** evaluate
+expressions inside `<script>`/`<style>` bodies, so their content is written literally — a
+`{\`…\`}` wrapper ships as text, which silently disables both and renders every page in both
+languages at once, off a green build.
+
+A page in this mode marks its own halves with `data-lang="en"` / `data-lang="es"` on a wrapper
+carrying **no display utility** (Tailwind's preflight `[hidden]`/`display` rules would
+out-specify nothing, but a `flex` on the wrapper itself would win over the rule above).
+
+The language toggle in this mode points at the **other language's home**, not at this path in
+the other language: the path a visitor is on here either does not exist (`/404`) or is a
+bounce stub (`/redirect`), so mirroring it would hand them a second dead end.
+
+**What does not switch:** the `<title>`. Copy-map §4 authors one title for each of these two
+routes, in English, and no meta description — switching it would mean inventing Spanish the
+copy map has not authored.
 
 **Usage:**
 
@@ -363,6 +399,35 @@ fetched value is the fallback, not the switch.
 (`serviceAreaNames`, read in the frontmatter for the area's bilingual name; ride tier
 labels, read in the result list).
 
+### ContactPage
+
+The body of `/contact` and `/es/contact` (wayfinder #39).
+
+**Location:** `src/components/ContactPage.astro`
+
+**Props:**
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `lang` | `"en" \| "es"` | **yes** | Selects the copy and the Tally form |
+
+Copy: `src/i18n/utilityCopy.ts` (`contactCopy`), verbatim from copy-map §3.7. Takes `lang`
+alone and resolves its own copy, the contract every page component here follows.
+
+**This page is load-bearing beyond its own content.** `/support` redirects here
+(`astro.config.mjs`, wayfinder #44), and that is the URL yeride-mobile submits to the app
+stores as its support contact — a missing one was a 2025 App Store rejection. The address on
+it was `support@yeride.app`, which nobody reads; §3.7 corrects it to `support@yeride.com`,
+and it is a `mailto:` link rather than plain text for the same reason `LegalDocument`
+linkifies it: it is the only action the page offers besides the form.
+
+**Two Tally forms, not one.** `TALLY_FORM_ID` maps language → form id. Tally has no runtime
+localisation and §3.7 requires the Spanish questions to be **authored**, not translated, so
+`/es/contact` embeds its own form; embedding the English `mJa5J7` under Spanish chrome is the
+half-translated page #65 was re-opened over. An unset or English-falling-back id **throws at
+build time** rather than rendering — the failure is silent by nature, since a wrong-language
+form looks perfectly healthy, and this site's standing rule is that a missing value stops the
+build instead of becoming a plausible default (#40's `$0.00`, #62's humanised area id).
+
 ## Page-Specific Components
 
 ### Homepage (index.astro)
@@ -374,14 +439,10 @@ before are all gone.
 
 ### Contact Page (contact.astro)
 
-**Contact Cards**
-- Email contact information
-- Location information
-- Response time expectations
-
-**Tally Form Embed**
-- Embedded iframe from Tally.so
-- Contact form functionality
+Nothing page-specific any more: `contact.astro` is a thin `BaseLayout` + `ContactPage`
+wrapper (wayfinder #39). The three shadow cards documented here before are gone — §3.7 cut
+"Response Time — Within 24 hours" as an unbacked service promise and replaced "Location —
+United States" with the brand's South Florida line. See **ContactPage** above.
 
 ## Component Patterns
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -43,9 +43,11 @@ expressions inside `<script>`/`<style>` bodies, so their content is written lite
 `{\`…\`}` wrapper ships as text, which silently disables both and renders every page in both
 languages at once, off a green build.
 
-A page in this mode marks its own halves with `data-lang="en"` / `data-lang="es"` on a wrapper
-carrying **no display utility** (Tailwind's preflight `[hidden]`/`display` rules would
-out-specify nothing, but a `flex` on the wrapper itself would win over the rule above).
+A page in this mode marks its own halves with `data-lang="en"` / `data-lang="es"` on a
+wrapper. A display utility on that wrapper is safe: `html:not([data-lang="es"])
+[data-lang="es"]` scores (0,2,1) against `.flex`'s (0,1,0) and the preset sets no
+`important`, so the hiding rule wins — **measured**, after a first draft of this document
+claimed the opposite.
 
 The language toggle in this mode points at the **other language's home**, not at this path in
 the other language: the path a visitor is on here either does not exist (`/404`) or is a
@@ -399,9 +401,35 @@ fetched value is the fallback, not the switch.
 (`serviceAreaNames`, read in the frontmatter for the area's bilingual name; ride tier
 labels, read in the result list).
 
+### NotFoundPage / RedirectPage
+
+The bodies of `/404` and `/redirect` (wayfinder #39).
+
+**Location:** `src/components/NotFoundPage.astro`, `src/components/RedirectPage.astro`
+
+**Props: none** — and they are the only page components without `lang`. They render **both**
+languages and let `BaseLayout`'s `bilingual` mode reveal one, so there is no second render to
+pass a language to. Both iterate `BILINGUAL_LANGS` from `src/i18n/utilityCopy.ts`, one shared
+constant, so they cannot disagree about which languages ship.
+
+Copy: `notFoundCopy` and `redirectCopy` in `src/i18n/utilityCopy.ts`, verbatim from
+copy-map §3.10 and §3.11.
+
+**`RedirectPage`'s Spanish half is unreachable today**, and the file says so rather than
+implying otherwise: §3.11 prescribes the same path-based switch `/404` uses, but the mobile
+app opens `yeride.com/redirect` directly and nothing links an `/es/` variant, so
+`location.pathname` is always `/redirect`. The ES copy ships because §3.11 authors it, not
+because it renders.
+
+`RedirectPage` reveals its manual fallback link after 2s by clearing `hidden` from **every**
+`[data-manual-link]` — both language copies — which is safe because the wrapper keeps the
+wrong language out of view regardless.
+
 ### ContactPage
 
-The body of `/contact` and `/es/contact` (wayfinder #39).
+The body of `/contact` (wayfinder #39). `/es/contact` **does not exist yet** — it is blocked
+on a Spanish Tally form that has not been created (copy-map §6.5), and `scripts/check-route-parity.mjs`
+carries `contact` in `PENDING` until it does.
 
 **Location:** `src/components/ContactPage.astro`
 
@@ -422,11 +450,25 @@ linkifies it: it is the only action the page offers besides the form.
 
 **Two Tally forms, not one.** `TALLY_FORM_ID` maps language → form id. Tally has no runtime
 localisation and §3.7 requires the Spanish questions to be **authored**, not translated, so
-`/es/contact` embeds its own form; embedding the English `mJa5J7` under Spanish chrome is the
-half-translated page #65 was re-opened over. An unset or English-falling-back id **throws at
-build time** rather than rendering — the failure is silent by nature, since a wrong-language
-form looks perfectly healthy, and this site's standing rule is that a missing value stops the
-build instead of becoming a plausible default (#40's `$0.00`, #62's humanised area id).
+`/es/contact` will embed its own form; embedding the English `mJa5J7` under Spanish chrome is
+the half-translated page #65 was re-opened over.
+
+Three build-time throws guard it, because the failure is silent by nature — a wrong-language
+form looks perfectly healthy:
+
+1. **The route must agree with `lang`.** This one an independent review had to teach the
+   file: the first version keyed only on the `lang` prop, and nothing ties an `/es/` route
+   to `lang="es"`. Measured — `src/pages/es/contact.astro` rendering `<ContactPage lang="en" />`
+   built **green** and shipped the English form under Spanish chrome, the exact failure the
+   guard claimed to prevent. Route-parity only checks that a *file* exists, so the route is
+   the fact worth checking.
+2. **The id must be shaped like a Tally id** (`/^[A-Za-z0-9]{4,12}$/`). Absent, still the
+   `"PENDING"` sentinel, or empty all fail — an empty one would embed `tally.so/embed/?…`,
+   a blank panel rather than an error.
+3. **No two languages may share an id.**
+
+What none of them catch, stated rather than left to be found: a well-formed id that is simply
+the wrong form. Nothing in the build can tell `mJa5J7` from `mJa5J8`.
 
 ## Page-Specific Components
 

--- a/scripts/check-route-parity.mjs
+++ b/scripts/check-route-parity.mjs
@@ -24,7 +24,6 @@ const PENDING = {
   // ES twin is blocked OUTSIDE this repo, on yeapptech/yeride-brand#22's
   // authored ES identity paragraph. Nothing here can retire it.
   about: "#85 — the identity page",
-  contact: "#39 — utility pages",
 };
 
 function walk(dir) {

--- a/scripts/check-route-parity.mjs
+++ b/scripts/check-route-parity.mjs
@@ -20,7 +20,10 @@ const EXEMPT = new Set(["404", "redirect"]);
 // The list cannot go stale: an entry whose twin now exists, or whose EN page has
 // gone, fails the check.
 const PENDING = {
-  about: "#39 — utility pages",
+  // #39 split /about out to #85 on 2026-08-04: it is the only route left whose
+  // ES twin is blocked OUTSIDE this repo, on yeapptech/yeride-brand#22's
+  // authored ES identity paragraph. Nothing here can retire it.
+  about: "#85 — the identity page",
   contact: "#39 — utility pages",
 };
 

--- a/src/components/ContactPage.astro
+++ b/src/components/ContactPage.astro
@@ -1,0 +1,98 @@
+---
+// /contact and /es/contact (wayfinder #39). Copy VERBATIM from copy-map §3.7;
+// §4's title and meta description sit on the page files.
+//
+// Takes `lang` alone and resolves its own copy from src/i18n — the contract
+// docs/components.md sets for page components.
+//
+// This is the URL yeride-mobile submits to the app stores as its support
+// contact (/support redirects here, wayfinder #44), so the address on it is
+// load-bearing: it was support@yeride.app, which nobody reads, and §3.7
+// corrects it to support@yeride.com.
+//
+// Removed by §3.7 and not to be restored: the "Response Time — Within 24
+// hours" card, an unbacked service promise, and "Location — United States",
+// replaced by the brand's own South Florida line.
+import { contactCopy } from "../i18n/utilityCopy";
+import type { Lang } from "../i18n/feesCopy";
+
+export interface Props {
+  lang: Lang;
+}
+const { lang } = Astro.props;
+const t = contactCopy[lang];
+
+// Two Tally forms, not one embed with a language parameter: Tally has no
+// runtime localisation, and §3.7 requires the ES questions to be AUTHORED
+// rather than translated. Embedding mJa5J7 under Spanish chrome would ship the
+// half-translated page #65 was re-opened over — an English form under a
+// Spanish heading, on a money-adjacent surface.
+const TALLY_FORM_ID: Record<Lang, string> = {
+  en: "mJa5J7",
+  es: "PENDING",
+};
+
+// Fail the BUILD, not the page. The failure this guards is silent by nature —
+// an unfilled id renders a perfectly healthy-looking form in the wrong
+// language, and nothing downstream would notice. Same rule the rest of this
+// site runs on: a missing value is a gap that stops the build, never a
+// plausible-looking default (#40's $0.00, #62's humanised area id).
+const formId = TALLY_FORM_ID[lang];
+if (formId === "PENDING" || formId === TALLY_FORM_ID.en && lang === "es") {
+  throw new Error(
+    `ContactPage: no Tally form id for "${lang}". /es/contact needs its own ` +
+      `Spanish form (copy-map §3.7, §6.5) — it must not fall back to the ` +
+      `English one. Set TALLY_FORM_ID.es in src/components/ContactPage.astro.`,
+  );
+}
+---
+
+<main class="bg-paper">
+  <div class="mx-auto w-full max-w-3xl px-5 pb-20 pt-10 sm:px-6 md:pb-28 md:pt-16">
+    <h1
+      class="font-extrabold tracking-headline text-[2rem] leading-[1.06] text-ink sm:text-[2.5rem]"
+    >
+      {t.h1}
+    </h1>
+    <p class="mt-6 text-[17px] leading-relaxed text-ink/80">{t.lead}</p>
+
+    <dl class="mt-10 grid gap-6 sm:grid-cols-2">
+      <div>
+        <dt class="text-xs font-bold uppercase tracking-caps text-ink/55">
+          {t.emailLabel}
+        </dt>
+        <dd class="mt-2 text-[17px] font-semibold text-ink">
+          <a
+            href={`mailto:${t.email}`}
+            class="underline underline-offset-4 hover:no-underline">{t.email}</a
+          >
+        </dd>
+      </div>
+      <div>
+        <dt class="text-xs font-bold uppercase tracking-caps text-ink/55">
+          {t.placeLabel}
+        </dt>
+        <dd class="mt-2 text-[17px] text-ink">{t.place}</dd>
+      </div>
+    </dl>
+
+    <section class="mt-14">
+      <h2
+        class="font-extrabold tracking-headline text-[1.25rem] leading-tight text-ink"
+      >
+        {t.formHeading}
+      </h2>
+      <div class="mt-6">
+        <iframe
+          data-tally-src={`https://tally.so/embed/${formId}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1`}
+          loading="lazy"
+          width="100%"
+          height="600"
+          title={t.formTitle}
+          class="w-full rounded-2xl border-0"></iframe>
+      </div>
+    </section>
+  </div>
+</main>
+
+<script is:inline src="https://tally.so/widgets/embed.js" async></script>

--- a/src/components/ContactPage.astro
+++ b/src/components/ContactPage.astro
@@ -8,7 +8,23 @@
 // This is the URL yeride-mobile submits to the app stores as its support
 // contact (/support redirects here, wayfinder #44), so the address on it is
 // load-bearing: it was support@yeride.app, which nobody reads, and §3.7
-// corrects it to support@yeride.com.
+// corrects it to support@yeride.com. The store requirement is a reachable
+// support URL, not a form.
+//
+// THERE IS NO FORM, and that is the decision rather than an omission (#39).
+// The page carried an embedded Tally form; §3.7 was amended to drop it. Three
+// things settled it. The form's questions lived inside Tally — the last
+// user-facing copy on this site outside the repo, invisible to the copy map and
+// to both copy gates, and unauthored in Spanish because Tally has no runtime
+// localisation, so shipping /es/contact meant a SECOND form kept in sync by
+// hand forever. Removing it deletes a named processor from a privacy policy
+// that is held for legal sign-off, which is a simpler edit than swapping one
+// vendor for another. And the address is already a live mailto: in both legal
+// documents, so publishing it here exposes nothing new.
+//
+// If structured intake is wanted later, the shape to copy is
+// PreRegistrationForm.astro — markup and per-field EN/ES copy in src/i18n,
+// posting to an endpoint YeRide owns — not a third-party embed.
 //
 // Removed by §3.7 and not to be restored: the "Response Time — Within 24
 // hours" card, an unbacked service promise, and "Location — United States",
@@ -21,73 +37,6 @@ export interface Props {
 }
 const { lang } = Astro.props;
 const t = contactCopy[lang];
-
-// Two Tally forms, not one embed with a language parameter: Tally has no
-// runtime localisation, and §3.7 requires the ES questions to be AUTHORED
-// rather than translated. Embedding mJa5J7 under Spanish chrome would ship the
-// half-translated page #65 was re-opened over — an English form under a
-// Spanish heading, on a money-adjacent surface.
-// An id is ABSENT rather than a sentinel. A first pass used the string
-// "PENDING" and paired it with a shape rule — and "PENDING" is seven
-// alphanumerics, so the shape rule accepted it and the build went green ready
-// to embed `tally.so/embed/PENDING`. A sentinel that has to be remembered
-// separately is exactly what the shape rule was supposed to make unnecessary.
-const TALLY_FORM_ID: Partial<Record<Lang, string>> = {
-  en: "mJa5J7",
-  // es: not created yet — copy-map §6.5. Adding /es/contact without it fails
-  // the build below, by design.
-};
-
-// Fail the BUILD, not the page. The failure this guards is silent by nature —
-// a form in the wrong language renders perfectly healthily, and nothing
-// downstream notices. Same rule the rest of this site runs on: a missing value
-// is a gap that stops the build, never a plausible-looking default (#40's
-// $0.00, #62's humanised area id).
-//
-// The FIRST check is the one an independent review had to teach this file. The
-// guard originally keyed on `lang` alone, and nothing ties an /es/ route to
-// lang="es" — measured, a page at src/pages/es/contact.astro rendering
-// <ContactPage lang="en" /> built GREEN and shipped the English form under
-// Spanish chrome, the exact failure the guard claimed to make impossible.
-// Route-parity only checks that a file exists, so the route is the fact to
-// check against, not the prop.
-const path = Astro.url.pathname;
-const routeLang: Lang = path === "/es" || path.startsWith("/es/") ? "es" : "en";
-if (routeLang !== lang) {
-  throw new Error(
-    `ContactPage at "${path}" was rendered with lang="${lang}", but that route ` +
-      `is "${routeLang}". The route decides the language; a mismatch ships one ` +
-      `language's copy and Tally form under the other's chrome.`,
-  );
-}
-
-const formId = TALLY_FORM_ID[lang];
-// Absent or malformed. Tally ids are short alphanumerics; the shape rule is
-// what stops an empty string embedding `tally.so/embed/?…`, which renders as a
-// blank panel rather than an error. The typeof test comes FIRST and is not
-// decoration: `.test(undefined)` coerces to the string "undefined", nine
-// lowercase letters, which the pattern would happily accept.
-if (typeof formId !== "string" || !/^[A-Za-z0-9]{4,12}$/.test(formId)) {
-  throw new Error(
-    `ContactPage: TALLY_FORM_ID.${lang} is ${JSON.stringify(formId)}, which is ` +
-      `not a Tally form id. /es/contact cannot ship until its Spanish form ` +
-      `exists (copy-map §3.7, §6.5). Set it in src/components/ContactPage.astro.`,
-  );
-}
-// Every language needs its OWN form; a shared id is the half-translated page.
-const duplicate = Object.entries(TALLY_FORM_ID).find(
-  ([other, id]) => other !== lang && id === formId,
-);
-if (duplicate) {
-  throw new Error(
-    `ContactPage: TALLY_FORM_ID.${lang} is the same id as ` +
-      `TALLY_FORM_ID.${duplicate[0]} ("${formId}"). §3.7 requires the Spanish ` +
-      `questions AUTHORED, not the English form under Spanish chrome.`,
-  );
-}
-// What this CANNOT catch, said rather than left to be found: a well-formed id
-// that is simply the wrong form. Nothing here can tell mJa5J7 from mJa5J8 —
-// only opening the page can.
 ---
 
 <main class="bg-paper">
@@ -99,12 +48,12 @@ if (duplicate) {
     </h1>
     <p class="mt-6 text-[17px] leading-relaxed text-ink/80">{t.lead}</p>
 
-    <dl class="mt-10 grid gap-6 sm:grid-cols-2">
+    <dl class="mt-10 grid gap-8 sm:grid-cols-2">
       <div>
         <dt class="text-xs font-bold uppercase tracking-caps text-ink/55">
           {t.emailLabel}
         </dt>
-        <dd class="mt-2 text-[17px] font-semibold text-ink">
+        <dd class="mt-2 text-[19px] font-semibold text-ink">
           <a
             href={`mailto:${t.email}`}
             class="underline underline-offset-4 hover:no-underline">{t.email}</a
@@ -115,27 +64,8 @@ if (duplicate) {
         <dt class="text-xs font-bold uppercase tracking-caps text-ink/55">
           {t.placeLabel}
         </dt>
-        <dd class="mt-2 text-[17px] text-ink">{t.place}</dd>
+        <dd class="mt-2 text-[19px] text-ink">{t.place}</dd>
       </div>
     </dl>
-
-    <section class="mt-14">
-      <h2
-        class="font-extrabold tracking-headline text-[1.25rem] leading-tight text-ink"
-      >
-        {t.formHeading}
-      </h2>
-      <div class="mt-6">
-        <iframe
-          data-tally-src={`https://tally.so/embed/${formId}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1`}
-          loading="lazy"
-          width="100%"
-          height="600"
-          title={t.formHeading}
-          class="w-full rounded-2xl border-0"></iframe>
-      </div>
-    </section>
   </div>
 </main>
-
-<script is:inline src="https://tally.so/widgets/embed.js" async></script>

--- a/src/components/ContactPage.astro
+++ b/src/components/ContactPage.astro
@@ -27,24 +27,67 @@ const t = contactCopy[lang];
 // rather than translated. Embedding mJa5J7 under Spanish chrome would ship the
 // half-translated page #65 was re-opened over — an English form under a
 // Spanish heading, on a money-adjacent surface.
-const TALLY_FORM_ID: Record<Lang, string> = {
+// An id is ABSENT rather than a sentinel. A first pass used the string
+// "PENDING" and paired it with a shape rule — and "PENDING" is seven
+// alphanumerics, so the shape rule accepted it and the build went green ready
+// to embed `tally.so/embed/PENDING`. A sentinel that has to be remembered
+// separately is exactly what the shape rule was supposed to make unnecessary.
+const TALLY_FORM_ID: Partial<Record<Lang, string>> = {
   en: "mJa5J7",
-  es: "PENDING",
+  // es: not created yet — copy-map §6.5. Adding /es/contact without it fails
+  // the build below, by design.
 };
 
 // Fail the BUILD, not the page. The failure this guards is silent by nature —
-// an unfilled id renders a perfectly healthy-looking form in the wrong
-// language, and nothing downstream would notice. Same rule the rest of this
-// site runs on: a missing value is a gap that stops the build, never a
-// plausible-looking default (#40's $0.00, #62's humanised area id).
-const formId = TALLY_FORM_ID[lang];
-if (formId === "PENDING" || formId === TALLY_FORM_ID.en && lang === "es") {
+// a form in the wrong language renders perfectly healthily, and nothing
+// downstream notices. Same rule the rest of this site runs on: a missing value
+// is a gap that stops the build, never a plausible-looking default (#40's
+// $0.00, #62's humanised area id).
+//
+// The FIRST check is the one an independent review had to teach this file. The
+// guard originally keyed on `lang` alone, and nothing ties an /es/ route to
+// lang="es" — measured, a page at src/pages/es/contact.astro rendering
+// <ContactPage lang="en" /> built GREEN and shipped the English form under
+// Spanish chrome, the exact failure the guard claimed to make impossible.
+// Route-parity only checks that a file exists, so the route is the fact to
+// check against, not the prop.
+const path = Astro.url.pathname;
+const routeLang: Lang = path === "/es" || path.startsWith("/es/") ? "es" : "en";
+if (routeLang !== lang) {
   throw new Error(
-    `ContactPage: no Tally form id for "${lang}". /es/contact needs its own ` +
-      `Spanish form (copy-map §3.7, §6.5) — it must not fall back to the ` +
-      `English one. Set TALLY_FORM_ID.es in src/components/ContactPage.astro.`,
+    `ContactPage at "${path}" was rendered with lang="${lang}", but that route ` +
+      `is "${routeLang}". The route decides the language; a mismatch ships one ` +
+      `language's copy and Tally form under the other's chrome.`,
   );
 }
+
+const formId = TALLY_FORM_ID[lang];
+// Absent or malformed. Tally ids are short alphanumerics; the shape rule is
+// what stops an empty string embedding `tally.so/embed/?…`, which renders as a
+// blank panel rather than an error. The typeof test comes FIRST and is not
+// decoration: `.test(undefined)` coerces to the string "undefined", nine
+// lowercase letters, which the pattern would happily accept.
+if (typeof formId !== "string" || !/^[A-Za-z0-9]{4,12}$/.test(formId)) {
+  throw new Error(
+    `ContactPage: TALLY_FORM_ID.${lang} is ${JSON.stringify(formId)}, which is ` +
+      `not a Tally form id. /es/contact cannot ship until its Spanish form ` +
+      `exists (copy-map §3.7, §6.5). Set it in src/components/ContactPage.astro.`,
+  );
+}
+// Every language needs its OWN form; a shared id is the half-translated page.
+const duplicate = Object.entries(TALLY_FORM_ID).find(
+  ([other, id]) => other !== lang && id === formId,
+);
+if (duplicate) {
+  throw new Error(
+    `ContactPage: TALLY_FORM_ID.${lang} is the same id as ` +
+      `TALLY_FORM_ID.${duplicate[0]} ("${formId}"). §3.7 requires the Spanish ` +
+      `questions AUTHORED, not the English form under Spanish chrome.`,
+  );
+}
+// What this CANNOT catch, said rather than left to be found: a well-formed id
+// that is simply the wrong form. Nothing here can tell mJa5J7 from mJa5J8 —
+// only opening the page can.
 ---
 
 <main class="bg-paper">
@@ -88,7 +131,7 @@ if (formId === "PENDING" || formId === TALLY_FORM_ID.en && lang === "es") {
           loading="lazy"
           width="100%"
           height="600"
-          title={t.formTitle}
+          title={t.formHeading}
           class="w-full rounded-2xl border-0"></iframe>
       </div>
     </section>

--- a/src/components/NotFoundPage.astro
+++ b/src/components/NotFoundPage.astro
@@ -1,0 +1,49 @@
+---
+// The body of /404 (wayfinder #39). Copy VERBATIM from copy-map §3.10.
+//
+// The one page-component contract this and RedirectPage do NOT follow is
+// `lang`: they take no props, because they render BOTH languages and let
+// BaseLayout's `bilingual` mode reveal one. GitHub Pages answers every missing
+// path with a single root 404.html, so /es/404 is unreachable and there is no
+// second render to pass a language to.
+import { BILINGUAL_LANGS, notFoundCopy } from "../i18n/utilityCopy";
+---
+
+<main class="bg-paper">
+  <div class="mx-auto w-full max-w-3xl px-5 pb-24 pt-16 sm:px-6 md:pb-32 md:pt-24">
+    {
+      BILINGUAL_LANGS.map((lang) => {
+        const t = notFoundCopy[lang];
+        const prefix = lang === "es" ? "/es" : "";
+        return (
+          <div data-lang={lang}>
+            <h1 class="font-extrabold tracking-headline text-[2rem] leading-[1.06] text-ink sm:text-[2.5rem]">
+              {t.h1}
+            </h1>
+            <p class="mt-4 text-[17px] leading-relaxed text-ink/70">{t.sub}</p>
+            <nav class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-[15px] font-semibold">
+              <a
+                href={`${prefix}/`}
+                class="underline underline-offset-4 hover:no-underline"
+              >
+                {t.home}
+              </a>
+              <a
+                href={`${prefix}/fees`}
+                class="underline underline-offset-4 hover:no-underline"
+              >
+                {t.fees}
+              </a>
+              <a
+                href={`${prefix}/fare-estimate`}
+                class="underline underline-offset-4 hover:no-underline"
+              >
+                {t.estimate}
+              </a>
+            </nav>
+          </div>
+        );
+      })
+    }
+  </div>
+</main>

--- a/src/components/RedirectPage.astro
+++ b/src/components/RedirectPage.astro
@@ -1,0 +1,48 @@
+---
+// The body of /redirect (wayfinder #39). Copy VERBATIM from copy-map §3.11.
+// Takes no props, for the reason given in NotFoundPage.astro.
+//
+// KNOWN, and said rather than glossed: the Spanish half here is currently
+// UNREACHABLE. §3.11 prescribes the same path-based switch /404 uses, but the
+// mobile app opens `yeride.com/redirect` directly and nothing links an /es/
+// variant, so `location.pathname` is always `/redirect` and the ES copy never
+// reveals. It is shipped because §3.11 authors it and because the switch is the
+// mechanism §3.11 specifies — not because it does anything today. If the app
+// ever links a Spanish entry point, that URL is what makes this live.
+import { BILINGUAL_LANGS, redirectCopy } from "../i18n/utilityCopy";
+---
+
+<main class="bg-paper">
+  <div class="mx-auto w-full max-w-3xl px-5 pb-24 pt-16 sm:px-6 md:pb-32 md:pt-24">
+    {
+      BILINGUAL_LANGS.map((lang) => {
+        const t = redirectCopy[lang];
+        return (
+          <div data-lang={lang}>
+            <p class="text-[17px] leading-relaxed text-ink/80">{t.body}</p>
+            {/* Hidden until the bounce has had time to fail. Both language
+                copies carry the class; the wrapper above keeps the wrong one
+                out of view regardless. */}
+            <a
+              href="yeride://register"
+              data-manual-link
+              class="mt-4 hidden text-[15px] font-semibold underline underline-offset-4 hover:no-underline"
+            >
+              {t.fallback}
+            </a>
+          </div>
+        );
+      })
+    }
+  </div>
+</main>
+
+<script>
+  window.location.href = "yeride://register";
+
+  setTimeout(() => {
+    document
+      .querySelectorAll("[data-manual-link]")
+      .forEach((link) => link.classList.remove("hidden"));
+  }, 2000);
+</script>

--- a/src/i18n/legalCopy.ts
+++ b/src/i18n/legalCopy.ts
@@ -90,12 +90,18 @@ export const privacyCopy: Record<Lang, LegalDoc> = {
             "estimate uses Google Maps and Firebase. Those companies can store data " +
             "in your browser, and what they do with it is governed by their own " +
             "privacy policies.",
-          // Says only what a reader can check. An earlier draft added "and mail
-          // you send us arrives with us directly", which claims there is no
-          // intermediary — and support@yeride.com necessarily resolves through
-          // a mail provider that handles the message. Who that is, and whether
-          // §4 should name them, is a real question this policy has never
-          // answered; it is not one to settle by asserting the opposite here.
+          // Says only what a reader can check, and deliberately says no more.
+          //
+          // An earlier draft added "and mail you send us arrives with us
+          // directly", which asserts there is no intermediary —
+          // support@yeride.com resolves through a mail provider that handles
+          // the message, so that was a claim this policy cannot support. Cut.
+          //
+          // DECIDED 2026-08-06: §4 does not name the mail host. So this line
+          // must stay silent on the subject rather than swing to either side —
+          // it neither names a provider nor denies one. Do not "improve" it by
+          // adding reassurance about where mail goes; that is the claim that
+          // was removed, and the silence is deliberate, not an omission.
           "Our contact page carries no form; it gives you an email address instead.",
           "The site itself is served by GitHub Pages, which records the usual " +
             "web-server information — such as your IP address and browser — in " +

--- a/src/i18n/legalCopy.ts
+++ b/src/i18n/legalCopy.ts
@@ -90,8 +90,13 @@ export const privacyCopy: Record<Lang, LegalDoc> = {
             "estimate uses Google Maps and Firebase. Those companies can store data " +
             "in your browser, and what they do with it is governed by their own " +
             "privacy policies.",
-          "Our contact page carries no form. It gives you an email address, and " +
-            "mail you send us arrives with us directly.",
+          // Says only what a reader can check. An earlier draft added "and mail
+          // you send us arrives with us directly", which claims there is no
+          // intermediary — and support@yeride.com necessarily resolves through
+          // a mail provider that handles the message. Who that is, and whether
+          // §4 should name them, is a real question this policy has never
+          // answered; it is not one to settle by asserting the opposite here.
+          "Our contact page carries no form; it gives you an email address instead.",
           "The site itself is served by GitHub Pages, which records the usual " +
             "web-server information — such as your IP address and browser — in " +
             "order to deliver the page to you. Those logs are GitHub's; we do not " +
@@ -293,8 +298,8 @@ export const privacyCopy: Record<Lang, LegalDoc> = {
             "estimador de tarifa usa Google Maps y Firebase. Esas empresas pueden " +
             "guardar datos en su navegador, y lo que hagan con ellos se rige por sus " +
             "propias políticas de privacidad.",
-          "Nuestra página de contacto no tiene formulario. Le damos una dirección de " +
-            "correo, y lo que usted nos escriba llega directamente a nosotros.",
+          "Nuestra página de contacto no tiene formulario; en su lugar le damos " +
+            "una dirección de correo.",
           "El sitio en sí lo sirve GitHub Pages, que registra la información " +
             "habitual de un servidor web —como su dirección IP y su navegador— para " +
             "poder entregarle la página. Esos registros son de GitHub; nosotros no " +

--- a/src/i18n/legalCopy.ts
+++ b/src/i18n/legalCopy.ts
@@ -86,12 +86,12 @@ export const privacyCopy: Record<Lang, LegalDoc> = {
             "and the service area — never where you are going.",
           "YeRide sets no cookies on this site, runs no analytics and shows no " +
             "advertising. We add no tracking of our own to any page.",
-          "Two pages do load code from other companies in order to work: the fare " +
-            "estimate uses Google Maps and Firebase, and the contact page embeds " +
-            "Tally's form. Those companies can store data in your browser, and what " +
-            "they do with it is governed by their own privacy policies.",
-          "The message form on our contact page is hosted by Tally. What you type " +
-            "into it goes to Tally, who deliver it to us.",
+          "One page does load code from other companies in order to work: the fare " +
+            "estimate uses Google Maps and Firebase. Those companies can store data " +
+            "in your browser, and what they do with it is governed by their own " +
+            "privacy policies.",
+          "Our contact page carries no form. It gives you an email address, and " +
+            "mail you send us arrives with us directly.",
           "The site itself is served by GitHub Pages, which records the usual " +
             "web-server information — such as your IP address and browser — in " +
             "order to deliver the page to you. Those logs are GitHub's; we do not " +
@@ -166,7 +166,6 @@ export const privacyCopy: Record<Lang, LegalDoc> = {
             "Google — Firebase holds our accounts, database, files and crash " +
               "reports; Google Maps provides place suggestions, routes and navigation.",
             "Stripe — card payments and driver payouts.",
-            "Tally — the message form on our contact page.",
             "Expo — push notifications are sent through Expo, which receives your " +
               "device's notification token and the text of the notification. That " +
               "text can name a person, such as the driver assigned to your trip. " +
@@ -290,13 +289,12 @@ export const privacyCopy: Record<Lang, LegalDoc> = {
             "duración y el área de servicio, nunca a dónde va usted.",
           "YeRide no coloca cookies en este sitio, no ejecuta analítica y no " +
             "muestra publicidad. No añadimos rastreo propio a ninguna página.",
-          "Dos páginas sí cargan código de otras empresas para poder funcionar: el " +
-            "estimador de tarifa usa Google Maps y Firebase, y la página de contacto " +
-            "incrusta el formulario de Tally. Esas empresas pueden guardar datos en " +
-            "su navegador, y lo que hagan con ellos se rige por sus propias " +
-            "políticas de privacidad.",
-          "El formulario de mensajes de nuestra página de contacto está alojado por " +
-            "Tally. Lo que usted escriba allí llega a Tally, que nos lo entrega.",
+          "Una página sí carga código de otras empresas para poder funcionar: el " +
+            "estimador de tarifa usa Google Maps y Firebase. Esas empresas pueden " +
+            "guardar datos en su navegador, y lo que hagan con ellos se rige por sus " +
+            "propias políticas de privacidad.",
+          "Nuestra página de contacto no tiene formulario. Le damos una dirección de " +
+            "correo, y lo que usted nos escriba llega directamente a nosotros.",
           "El sitio en sí lo sirve GitHub Pages, que registra la información " +
             "habitual de un servidor web —como su dirección IP y su navegador— para " +
             "poder entregarle la página. Esos registros son de GitHub; nosotros no " +
@@ -379,7 +377,6 @@ export const privacyCopy: Record<Lang, LegalDoc> = {
               "y los informes de error; Google Maps aporta las sugerencias de " +
               "lugares, las rutas y la navegación.",
             "Stripe: los pagos con tarjeta y los pagos a los conductores.",
-            "Tally: el formulario de mensajes de nuestra página de contacto.",
             "Expo: las notificaciones se envían a través de Expo, que recibe el " +
               "token de notificación de su dispositivo y el texto de la " +
               "notificación. Ese texto puede nombrar a una persona, como el " +

--- a/src/i18n/utilityCopy.ts
+++ b/src/i18n/utilityCopy.ts
@@ -10,6 +10,10 @@
 // shipped HTML at the same time.
 import type { Lang } from "./feesCopy";
 
+/** The render order for a bilingual page's halves. Shared by NotFoundPage and
+ *  RedirectPage so the two cannot disagree about which languages ship. */
+export const BILINGUAL_LANGS = ["en", "es"] as const satisfies readonly Lang[];
+
 export const contactCopy = {
   en: {
     h1: "Contact us",
@@ -19,7 +23,6 @@ export const contactCopy = {
     placeLabel: "Where we are",
     place: "Built in South Florida.",
     formHeading: "Send us a message",
-    formTitle: "Contact form",
   },
   es: {
     h1: "Contáctanos",
@@ -29,7 +32,6 @@ export const contactCopy = {
     placeLabel: "Dónde estamos",
     place: "Hecho en el Sur de la Florida.",
     formHeading: "Mándanos un mensaje",
-    formTitle: "Formulario de contacto",
   },
 } satisfies Record<Lang, unknown>;
 

--- a/src/i18n/utilityCopy.ts
+++ b/src/i18n/utilityCopy.ts
@@ -22,7 +22,6 @@ export const contactCopy = {
     email: "support@yeride.com",
     placeLabel: "Where we are",
     place: "Built in South Florida.",
-    formHeading: "Send us a message",
   },
   es: {
     h1: "Contáctanos",
@@ -31,7 +30,6 @@ export const contactCopy = {
     email: "support@yeride.com",
     placeLabel: "Dónde estamos",
     place: "Hecho en el Sur de la Florida.",
-    formHeading: "Mándanos un mensaje",
   },
 } satisfies Record<Lang, unknown>;
 

--- a/src/i18n/utilityCopy.ts
+++ b/src/i18n/utilityCopy.ts
@@ -1,0 +1,62 @@
+// /contact, /404 and /redirect copy — VERBATIM from docs/copy-map.md §3.7,
+// §3.10 and §3.11 (wayfinder #34). Do not reword, re-case, or re-punctuate.
+// §4's title and meta description sit on the page files, as they do everywhere.
+//
+// /404 and /redirect are ONE file each serving both languages (§3.10, §3.11):
+// GitHub Pages serves a single root 404.html for every missing path, so /es/404
+// is unreachable. Both language sets therefore ship in the same page and the
+// switch happens client-side off `location.pathname` — which is why these two
+// are the only copy objects on the site whose EN and ES halves are both in the
+// shipped HTML at the same time.
+import type { Lang } from "./feesCopy";
+
+export const contactCopy = {
+  en: {
+    h1: "Contact us",
+    lead: "Questions, problems, or something we got wrong — write to us.",
+    emailLabel: "Email",
+    email: "support@yeride.com",
+    placeLabel: "Where we are",
+    place: "Built in South Florida.",
+    formHeading: "Send us a message",
+    formTitle: "Contact form",
+  },
+  es: {
+    h1: "Contáctanos",
+    lead: "Preguntas, problemas o algo que hicimos mal — escríbenos.",
+    emailLabel: "Correo",
+    email: "support@yeride.com",
+    placeLabel: "Dónde estamos",
+    place: "Hecho en el Sur de la Florida.",
+    formHeading: "Mándanos un mensaje",
+    formTitle: "Formulario de contacto",
+  },
+} satisfies Record<Lang, unknown>;
+
+export const notFoundCopy = {
+  en: {
+    h1: "We can't find that page.",
+    sub: "It may have moved, or the link may be wrong.",
+    home: "Home",
+    fees: "Fees",
+    estimate: "Fare estimate",
+  },
+  es: {
+    h1: "No encontramos esa página.",
+    sub: "Puede que se haya movido o que el enlace esté mal.",
+    home: "Inicio",
+    fees: "Tarifas",
+    estimate: "Estimar tarifa",
+  },
+} satisfies Record<Lang, unknown>;
+
+export const redirectCopy = {
+  en: {
+    body: "Opening YeRide…",
+    fallback: "Not redirected? Open YeRide.",
+  },
+  es: {
+    body: "Abriendo YeRide…",
+    fallback: "¿No abrió? Abre YeRide.",
+  },
+} satisfies Record<Lang, unknown>;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,6 +19,13 @@ export interface Props {
   /** /404 and /redirect are single-file with a client-side language switch
    *  (copy-map §3.10–3.11) — they carry no hreflang alternates. */
   alternates?: boolean;
+  /** Those same two pages, and only those two: ship BOTH languages of the
+   *  chrome and reveal one client-side. GitHub Pages serves a single root
+   *  404.html for every missing path, so a Spanish visitor at /es/anything
+   *  lands here — and header and footer are page copy like any other. Leaving
+   *  them English would ship Spanish content under English navigation, the
+   *  half-translated page #65 and #62 were re-opened over. */
+  bilingual?: boolean;
 }
 const {
   title,
@@ -26,6 +33,7 @@ const {
   lang = "en",
   headerGround = "paper",
   alternates = true,
+  bilingual = false,
 } = Astro.props;
 
 // Routes are mirrored with English slugs: /fees ⇄ /es/fees (copy-map §0.3).
@@ -58,10 +66,69 @@ const toggleHref = lang === "es" ? enPath : esPath;
     <link rel="icon" type="image/png" sizes="16x16" href={favicon16.src} />
     <link rel="icon" type="image/png" sizes="32x32" href={favicon32.src} />
     <link rel="icon" type="image/png" sizes="48x48" href={favicon48.src} />
+    {
+      bilingual && (
+        <>
+          {/* Runs in <head>, before the body is parsed, so the correct
+              language is already chosen when the first pixel is painted —
+              a switch that ran on DOMContentLoaded would flash English at
+              every Spanish visitor. It only stamps the root; the CSS below
+              does the hiding. */}
+          <script is:inline>
+            (function () {
+              var p = location.pathname;
+              if (p === "/es" || p.indexOf("/es/") === 0) {
+                document.documentElement.lang = "es";
+                document.documentElement.setAttribute("data-lang", "es");
+              }
+            })();
+          </script>
+          {/* Not a scoped <style>: these selectors have to reach through
+              <slot> into the page's own halves, and scoping keys them to this
+              component's elements alone. The default — no data-lang, which is
+              what a visitor with JavaScript off gets — hides ES and shows EN,
+              matching copy-map §3.10's "renders English by default". */}
+          <style is:inline>
+            html:not([data-lang="es"]) [data-lang="es"] { display: none; }
+            html[data-lang="es"] [data-lang="en"] { display: none; }
+          </style>
+        </>
+      )
+    }
   </head>
   <body class="bg-paper font-brand text-ink">
-    <Header lang={lang} ground={headerGround} toggleHref={toggleHref} />
+    {
+      bilingual ? (
+        /* Both toggles point at the other language's HOME, not at this path in
+           the other language: the path a visitor is on here either does not
+           exist (/404) or is a bounce stub (/redirect), so mirroring it would
+           hand them a second dead end. */
+        <>
+          <div data-lang="en">
+            <Header lang="en" ground={headerGround} toggleHref="/es/" />
+          </div>
+          <div data-lang="es">
+            <Header lang="es" ground={headerGround} toggleHref="/" />
+          </div>
+        </>
+      ) : (
+        <Header lang={lang} ground={headerGround} toggleHref={toggleHref} />
+      )
+    }
     <slot />
-    <Footer lang={lang} />
+    {
+      bilingual ? (
+        <>
+          <div data-lang="en">
+            <Footer lang="en" />
+          </div>
+          <div data-lang="es">
+            <Footer lang="es" />
+          </div>
+        </>
+      ) : (
+        <Footer lang={lang} />
+      )
+    }
   </body>
 </html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,8 @@ export interface Props {
    *  the ink-ground /fees page passes "ink". */
   headerGround?: "paper" | "yellow" | "ink";
   /** /404 and /redirect are single-file with a client-side language switch
-   *  (copy-map §3.10–3.11) — they carry no hreflang alternates. */
+   *  (copy-map §3.10–3.11) — they carry no hreflang alternates. Implied by
+   *  `bilingual`; pass it only to suppress alternates without the switch. */
   alternates?: boolean;
   /** Those same two pages, and only those two: ship BOTH languages of the
    *  chrome and reveal one client-side. GitHub Pages serves a single root
@@ -32,9 +33,24 @@ const {
   description,
   lang = "en",
   headerGround = "paper",
-  alternates = true,
+  alternates: alternatesProp = true,
   bilingual = false,
 } = Astro.props;
+
+// A bilingual page is one URL serving both languages, so there is no second URL
+// for an alternate to name. These were two independent props for one commit and
+// an independent review caught it at once: `bilingual` alone would have emitted
+// hreflang pointing at a twin that does not exist.
+const alternates = alternatesProp && !bilingual;
+
+// Chrome renders once per language in bilingual mode, twice-in-one-page, and the
+// halves are marked for the stylesheet below. Written as a list rather than two
+// near-identical ternaries so header and footer cannot drift apart.
+const chromeLangs = bilingual ? (["en", "es"] as const) : null;
+// On these pages the toggle goes to the other language's HOME, not to this path
+// in the other language: the path a visitor is on here either does not exist
+// (/404) or is a bounce stub (/redirect), so mirroring it is a second dead end.
+const bilingualToggle = { en: "/es/", es: "/" } as const;
 
 // Routes are mirrored with English slugs: /fees ⇄ /es/fees (copy-map §0.3).
 const path = Astro.url.pathname;
@@ -98,34 +114,28 @@ const toggleHref = lang === "es" ? enPath : esPath;
   </head>
   <body class="bg-paper font-brand text-ink">
     {
-      bilingual ? (
-        /* Both toggles point at the other language's HOME, not at this path in
-           the other language: the path a visitor is on here either does not
-           exist (/404) or is a bounce stub (/redirect), so mirroring it would
-           hand them a second dead end. */
-        <>
-          <div data-lang="en">
-            <Header lang="en" ground={headerGround} toggleHref="/es/" />
+      chromeLangs ? (
+        chromeLangs.map((l) => (
+          <div data-lang={l}>
+            <Header
+              lang={l}
+              ground={headerGround}
+              toggleHref={bilingualToggle[l]}
+            />
           </div>
-          <div data-lang="es">
-            <Header lang="es" ground={headerGround} toggleHref="/" />
-          </div>
-        </>
+        ))
       ) : (
         <Header lang={lang} ground={headerGround} toggleHref={toggleHref} />
       )
     }
     <slot />
     {
-      bilingual ? (
-        <>
-          <div data-lang="en">
-            <Footer lang="en" />
+      chromeLangs ? (
+        chromeLangs.map((l) => (
+          <div data-lang={l}>
+            <Footer lang={l} />
           </div>
-          <div data-lang="es">
-            <Footer lang="es" />
-          </div>
-        </>
+        ))
       ) : (
         <Footer lang={lang} />
       )

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,12 +1,58 @@
 ---
-// Single-file for every missing path (GitHub Pages serves one root 404.html);
-// the client-side language switch and copy-map content are ticket #39.
+// /404 — ONE file for every missing path in both languages (copy-map §3.10),
+// because GitHub Pages serves a single root 404.html and /es/404 is therefore
+// unreachable. Both halves ship in the HTML and BaseLayout's `bilingual` mode
+// reveals one off location.pathname; header and footer switch with them.
+//
+// Exempt from the route-parity check by name (§6.1). No hreflang alternates:
+// there is no pair of URLs to point them at.
+//
+// §4 authors ONE title for this route, English, and no meta description. That
+// is deliberate and stays: the tab title is the one string here that cannot
+// switch without inventing Spanish the copy map has not authored.
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { notFoundCopy } from "../i18n/utilityCopy";
+
+const LANGS = ["en", "es"] as const;
 ---
 
-<BaseLayout title="Page not found | YeRide" alternates={false}>
-  <main class="mx-auto w-full max-w-7xl px-5 py-16 sm:px-6">
-    <h1 class="text-3xl font-bold tracking-headline">404 Not Found</h1>
-    <a href="/" class="mt-4 inline-block font-semibold underline underline-offset-4 hover:no-underline">Go Home</a>
+<BaseLayout title="Page not found | YeRide" alternates={false} bilingual>
+  <main class="bg-paper">
+    <div class="mx-auto w-full max-w-3xl px-5 pb-24 pt-16 sm:px-6 md:pb-32 md:pt-24">
+      {
+        LANGS.map((lang) => {
+          const t = notFoundCopy[lang];
+          const prefix = lang === "es" ? "/es" : "";
+          return (
+            <div data-lang={lang}>
+              <h1 class="font-extrabold tracking-headline text-[2rem] leading-[1.06] text-ink sm:text-[2.5rem]">
+                {t.h1}
+              </h1>
+              <p class="mt-4 text-[17px] leading-relaxed text-ink/70">{t.sub}</p>
+              <nav class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-[15px] font-semibold">
+                <a
+                  href={`${prefix}/`}
+                  class="underline underline-offset-4 hover:no-underline"
+                >
+                  {t.home}
+                </a>
+                <a
+                  href={`${prefix}/fees`}
+                  class="underline underline-offset-4 hover:no-underline"
+                >
+                  {t.fees}
+                </a>
+                <a
+                  href={`${prefix}/fare-estimate`}
+                  class="underline underline-offset-4 hover:no-underline"
+                >
+                  {t.estimate}
+                </a>
+              </nav>
+            </div>
+          );
+        })
+      }
+    </div>
   </main>
 </BaseLayout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,58 +1,18 @@
 ---
-// /404 — ONE file for every missing path in both languages (copy-map §3.10),
-// because GitHub Pages serves a single root 404.html and /es/404 is therefore
-// unreachable. Both halves ship in the HTML and BaseLayout's `bilingual` mode
-// reveals one off location.pathname; header and footer switch with them.
+// /404 (wayfinder #39). Title per docs/copy-map.md §4.
 //
-// Exempt from the route-parity check by name (§6.1). No hreflang alternates:
-// there is no pair of URLs to point them at.
+// ONE file for every missing path in both languages (§3.10): GitHub Pages
+// answers every missing path with a single root 404.html, so /es/404 is
+// unreachable. Exempt from the route-parity check by name (§6.1), and no
+// hreflang alternates — there is no pair of URLs to point them at.
 //
 // §4 authors ONE title for this route, English, and no meta description. That
 // is deliberate and stays: the tab title is the one string here that cannot
 // switch without inventing Spanish the copy map has not authored.
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { notFoundCopy } from "../i18n/utilityCopy";
-
-const LANGS = ["en", "es"] as const;
+import NotFoundPage from "../components/NotFoundPage.astro";
 ---
 
-<BaseLayout title="Page not found | YeRide" alternates={false} bilingual>
-  <main class="bg-paper">
-    <div class="mx-auto w-full max-w-3xl px-5 pb-24 pt-16 sm:px-6 md:pb-32 md:pt-24">
-      {
-        LANGS.map((lang) => {
-          const t = notFoundCopy[lang];
-          const prefix = lang === "es" ? "/es" : "";
-          return (
-            <div data-lang={lang}>
-              <h1 class="font-extrabold tracking-headline text-[2rem] leading-[1.06] text-ink sm:text-[2.5rem]">
-                {t.h1}
-              </h1>
-              <p class="mt-4 text-[17px] leading-relaxed text-ink/70">{t.sub}</p>
-              <nav class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-[15px] font-semibold">
-                <a
-                  href={`${prefix}/`}
-                  class="underline underline-offset-4 hover:no-underline"
-                >
-                  {t.home}
-                </a>
-                <a
-                  href={`${prefix}/fees`}
-                  class="underline underline-offset-4 hover:no-underline"
-                >
-                  {t.fees}
-                </a>
-                <a
-                  href={`${prefix}/fare-estimate`}
-                  class="underline underline-offset-4 hover:no-underline"
-                >
-                  {t.estimate}
-                </a>
-              </nav>
-            </div>
-          );
-        })
-      }
-    </div>
-  </main>
+<BaseLayout title="Page not found | YeRide" bilingual>
+  <NotFoundPage />
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,8 @@
 ---
 // Body content below is pre-redesign — the brand rebuild of this page is
-// ticket #39.
+// ticket #85, split out of #39 because /es/about is blocked outside this repo
+// on yeapptech/yeride-brand#22's authored ES identity paragraph. EN and ES ship
+// together (copy-map §0.1), so this page waits for it in both languages.
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,113 +1,15 @@
 ---
-// Body content below is pre-redesign — the brand rebuild of this page is
-// ticket #39.
+// /contact (wayfinder #39). Title and meta description per docs/copy-map.md §4.
+// /support redirects here (astro.config.mjs, #44) — this is the URL the mobile
+// app submits to the app stores as its support contact.
 import BaseLayout from "../layouts/BaseLayout.astro";
-
-const TALLY_FORM_ID = "mJa5J7"; // Form ID from https://tally.so/r/mJa5J7
+import ContactPage from "../components/ContactPage.astro";
 ---
 
-<BaseLayout title="Contact Us - YeRide">
-  <main>
-    <div class="min-h-screen bg-gradient-to-br from-blue-50 to-white py-12 px-4 sm:px-6 lg:px-8">
-      <div class="max-w-4xl mx-auto">
-        <!-- Header Section -->
-        <div class="text-center mb-12">
-          <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
-            Get in Touch
-          </h1>
-          <p class="text-xl text-gray-600 max-w-2xl mx-auto">
-            Have questions about YeRide? We'd love to hear from you. Send us a message and we'll respond as soon as possible.
-          </p>
-        </div>
-
-        <!-- Contact Info Cards -->
-        <div class="grid md:grid-cols-3 gap-6 mb-12">
-          <div class="bg-white rounded-lg shadow-md p-6 text-center hover:shadow-lg transition duration-300">
-            <div class="inline-flex items-center justify-center w-12 h-12 bg-blue-100 rounded-full mb-4">
-              <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
-              </svg>
-            </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Email</h3>
-            <p class="text-gray-600">support@yeride.app</p>
-          </div>
-
-          <div class="bg-white rounded-lg shadow-md p-6 text-center hover:shadow-lg transition duration-300">
-            <div class="inline-flex items-center justify-center w-12 h-12 bg-green-100 rounded-full mb-4">
-              <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
-              </svg>
-            </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Location</h3>
-            <p class="text-gray-600">United States</p>
-          </div>
-
-          <div class="bg-white rounded-lg shadow-md p-6 text-center hover:shadow-lg transition duration-300">
-            <div class="inline-flex items-center justify-center w-12 h-12 bg-purple-100 rounded-full mb-4">
-              <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-              </svg>
-            </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Response Time</h3>
-            <p class="text-gray-600">Within 24 hours</p>
-          </div>
-        </div>
-
-        <!-- Tally Form Section -->
-        <div class="bg-white rounded-lg shadow-lg p-8">
-          <h2 class="text-2xl font-bold text-gray-900 mb-6 text-center">
-            Send Us a Message
-          </h2>
-
-          <!-- Tally Form Embed -->
-          <div id="tally-form-container" class="w-full">
-            <iframe
-              id="tally-form"
-              data-tally-src={`https://tally.so/embed/${TALLY_FORM_ID}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1`}
-              loading="lazy"
-              width="100%"
-              height="600"
-              title="Contact form"
-              class="rounded-lg border-0"
-            ></iframe>
-          </div>
-        </div>
-
-        <!-- Additional Help Section -->
-        <div class="mt-12 text-center">
-          <h3 class="text-xl font-semibold text-gray-900 mb-4">
-            Looking for something else?
-          </h3>
-          <div class="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
-              href="/#pre-registration"
-              class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition duration-300"
-            >
-              Pre-register Now
-            </a>
-            <a
-              href="/"
-              class="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 transition duration-300"
-            >
-              Back to Home
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </main>
-
-  <!-- Tally Form Widget Script -->
-  <script is:inline src="https://tally.so/widgets/embed.js"></script>
+<BaseLayout
+  title="Contact us | YeRide"
+  description="Questions, problems, or something we got wrong — reach the team behind YeRide."
+  lang="en"
+>
+  <ContactPage lang="en" />
 </BaseLayout>
-
-<style>
-  #tally-form-container {
-    min-height: 600px;
-  }
-
-  iframe[data-tally-src] {
-    border: none;
-  }
-</style>

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -1,0 +1,14 @@
+---
+// /es/contact — the ES twin. Routes are mirrored with English slugs
+// (copy-map §0.3). Title and meta description per §4.
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import ContactPage from "../../components/ContactPage.astro";
+---
+
+<BaseLayout
+  title="Contáctanos | YeRide"
+  description="Preguntas, problemas o algo que hicimos mal — escríbele al equipo de YeRide."
+  lang="es"
+>
+  <ContactPage lang="es" />
+</BaseLayout>

--- a/src/pages/redirect.astro
+++ b/src/pages/redirect.astro
@@ -1,49 +1,15 @@
 ---
-// /redirect — bounces to the yeride://register deep link. ONE file for both
-// languages (copy-map §3.11), same client-side switch as /404: the app opens
-// this URL directly, so there is no /es/ twin to send anyone to.
+// /redirect (wayfinder #39). Title per docs/copy-map.md §4.
 //
-// Exempt from the route-parity check by name (§6.1). §4 authors one title,
-// English, and no meta description — see the note in 404.astro.
+// Bounces to the yeride://register deep link. ONE file for both languages
+// (§3.11), same client-side switch as /404. Exempt from the route-parity check
+// by name (§6.1). §4 authors one title, English, and no meta description — see
+// the note in 404.astro. RedirectPage.astro records why the Spanish half of
+// this particular page is unreachable today.
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { redirectCopy } from "../i18n/utilityCopy";
-
-const LANGS = ["en", "es"] as const;
+import RedirectPage from "../components/RedirectPage.astro";
 ---
 
-<BaseLayout title="Opening YeRide…" alternates={false} bilingual>
-  <main class="bg-paper">
-    <div class="mx-auto w-full max-w-3xl px-5 pb-24 pt-16 sm:px-6 md:pb-32 md:pt-24">
-      {
-        LANGS.map((lang) => {
-          const t = redirectCopy[lang];
-          return (
-            <div data-lang={lang}>
-              <p class="text-[17px] leading-relaxed text-ink/80">{t.body}</p>
-              {/* Hidden until the bounce has had time to fail. Both language
-                  copies carry the class; the wrapper above keeps the wrong one
-                  out of view regardless. */}
-              <a
-                href="yeride://register"
-                data-manual-link
-                class="mt-4 hidden text-[15px] font-semibold underline underline-offset-4 hover:no-underline"
-              >
-                {t.fallback}
-              </a>
-            </div>
-          );
-        })
-      }
-    </div>
-  </main>
-
-  <script>
-    window.location.href = "yeride://register";
-
-    setTimeout(() => {
-      document
-        .querySelectorAll("[data-manual-link]")
-        .forEach((link) => link.classList.remove("hidden"));
-    }, 2000);
-  </script>
+<BaseLayout title="Opening YeRide…" bilingual>
+  <RedirectPage />
 </BaseLayout>

--- a/src/pages/redirect.astro
+++ b/src/pages/redirect.astro
@@ -1,22 +1,49 @@
 ---
-// Bounces to the yeride://register deep link. Single-file, no /es/ twin;
-// the client-side language switch and copy-map content are ticket #39.
+// /redirect — bounces to the yeride://register deep link. ONE file for both
+// languages (copy-map §3.11), same client-side switch as /404: the app opens
+// this URL directly, so there is no /es/ twin to send anyone to.
+//
+// Exempt from the route-parity check by name (§6.1). §4 authors one title,
+// English, and no meta description — see the note in 404.astro.
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { redirectCopy } from "../i18n/utilityCopy";
+
+const LANGS = ["en", "es"] as const;
 ---
 
-<BaseLayout title="Redirecting..." alternates={false}>
-  <main class="mx-auto w-full max-w-7xl px-5 py-16 sm:px-6">
-    <p>Redirecting to the app...</p>
-    <a id="manualLink" href="yeride://register" class="mt-4 hidden font-semibold underline underline-offset-4 hover:no-underline"
-      >Click here if you are not redirected</a
-    >
+<BaseLayout title="Opening YeRide…" alternates={false} bilingual>
+  <main class="bg-paper">
+    <div class="mx-auto w-full max-w-3xl px-5 pb-24 pt-16 sm:px-6 md:pb-32 md:pt-24">
+      {
+        LANGS.map((lang) => {
+          const t = redirectCopy[lang];
+          return (
+            <div data-lang={lang}>
+              <p class="text-[17px] leading-relaxed text-ink/80">{t.body}</p>
+              {/* Hidden until the bounce has had time to fail. Both language
+                  copies carry the class; the wrapper above keeps the wrong one
+                  out of view regardless. */}
+              <a
+                href="yeride://register"
+                data-manual-link
+                class="mt-4 hidden text-[15px] font-semibold underline underline-offset-4 hover:no-underline"
+              >
+                {t.fallback}
+              </a>
+            </div>
+          );
+        })
+      }
+    </div>
   </main>
 
   <script>
     window.location.href = "yeride://register";
 
     setTimeout(() => {
-      document.getElementById("manualLink")?.classList.remove("hidden");
+      document
+        .querySelectorAll("[data-manual-link]")
+        .forEach((link) => link.classList.remove("hidden"));
     }, 2000);
   </script>
 </BaseLayout>


### PR DESCRIPTION
Closes #39. Part of the redesign map #30.

**Draft on purpose.** It touches the privacy policy, which is legal copy held for sign-off in #66 — see *What needs your judgement* at the bottom. Everything else is verified.

## What ships

| Route | |
|---|---|
| `/contact`, `/es/contact` | Copy-map §3.7, both languages. **No form** — see below. Address corrected to `support@yeride.com`. |
| `/404` | One file, **both** languages including header and footer, revealed client-side. §3.10. |
| `/redirect` | Same mechanism. §3.11. |
| `/es/support` | Joins the redirect block, as the parity check demands once `/es/contact` exists. |

Route parity is now **11 EN / 8 ES** with only `about` pending, which belongs to #85.

## Three decisions worth reading

**`/contact` carries no form** (copy-map amended, `40c866e`). The page embedded Tally form `mJa5J7`, and §3.7 required a Spanish twin before `/es/contact` could ship. The blocker was never really the missing form — it was where the form's copy lived. Its questions were inside Tally: the last user-facing copy on this site outside the repo, unreadable by both copy gates, while §2.2 authors every label and placeholder of the pre-registration form in both languages. Tally has no runtime localisation, so honouring §0.2 meant a second form hand-synced forever, and under §0.1 that held `/contact` in **both** languages — one section blocking the last build ticket before the ship. Removing it also deletes a named processor from the privacy policy, which is a simpler change than swapping vendors; a Formspree-class replacement was considered and rejected on that ground, since it buys only what an endpoint YeRide owns would buy with no processor at all. That option is recorded in §3.7 as the shape to use if structured intake is ever wanted.

**`/404` switches its chrome, not just its content.** GitHub Pages answers every missing path with a single root `404.html`, so a Spanish visitor at `/es/anything` lands on the English build. Header and footer are page copy like everything else; leaving them English is the half-translated page #62 and #65 were re-opened over. `BaseLayout` gained a `bilingual` mode: an inline `<head>` script stamps `<html data-lang>` before the body parses, so nothing flashes, and an inline `:not()` stylesheet hides the wrong half — written so the **default state, which is what a visitor with JavaScript off gets, is English**, matching §3.10.

**`/about` was split to #85**, blocked on yeapptech/yeride-brand#22's authored ES identity paragraph. It was the only half of #39 blocked outside this repo, and leaving it here made one opaque ticket the sole blocker on the ship.

## Two defects found by reading output, not by the gates

The first cut of the bilingual switch wrapped the `<script>` and `<style>` bodies in `` {`…`} ``. Astro emits those literally, so the shipped page had a JS syntax error and invalid CSS — **every page would have rendered in both languages at once**, header and footer twice, off a fully green build.

An independent review (standards + spec + adversarial) then killed the Tally guard's headline claim: it keyed on the `lang` prop, and nothing tied an `/es/` route to `lang="es"`, so a page rendering `<ContactPage lang="en" />` built green and shipped the English form under Spanish chrome. Fixing it introduced a second bug in the same class — `"PENDING"` is seven alphanumerics, so the new shape rule accepted the sentinel the explicit check used to catch. Both are moot now that the form is gone, but the review is on #39 and the sequence is in the commit messages.

## Verification

- Full build green, **no new allowances** in either copy gate. `astro build` actually ran here.
- Zero occurrences of `tally` anywhere in `dist/`; both contact pages ship **0 iframes and 0 external scripts**.
- **12 assertions** of shipped strings against the amended §3.7 and §4, including that the cut "Form heading" row is absent from both pages.
- All four `/404` and `/redirect` language states rendered from `dist/` in a browser: exactly one header, one `h1` and one footer visible in each, three wrappers hidden.
- **0 horizontal overflow** at 390 and 1280, both languages, every page.
- `bilingual` now implies no `alternates` — verified 0 `hreflang` on both bilingual pages, 3 on a normal one.
- All three redirect aliases emit the same meta-refresh shape.
- `astro.config.mjs` is CRLF and **stayed** CRLF: 33 → 36 pairs, 0 bare LF, a 4-line diff.

## Said rather than glossed

- **`/redirect`'s Spanish half is unreachable today.** §3.11 prescribes the path switch `/404` uses, but the app opens `yeride.com/redirect` directly and nothing links an `/es/` variant, so `location.pathname` is always `/redirect`. It ships because §3.11 authors it, not because it renders; `RedirectPage.astro` says so.
- The revealed ES footer links `/es/about`, which does not exist yet (#85).
- `dist/404.html`'s canonical points at `/404/`, which is not a built directory. **Pre-existing**, not introduced here.
- The build ran against a throwaway placeholder `.env`, which exercises every gate but no live endpoint.

## Docs

`docs/architecture.md`, `.claude/agents/page-consistency.md` and `.claude/skills/nav-sync/SKILL.md` were rewritten (`47f600e`) because all three still described the **pre-#35** site and were inverted, not merely stale — `page-consistency` told a reviewer to require the Tailwind CDN tag and to fail a page for using `BaseLayout`. Requested explicitly; flagged here because it is the bulk of the line count.

## What needs your judgement

The privacy-policy changes are **legal copy in a document held for sign-off** (#44, #66). They are deletions plus two rewritten sentences per language: EN "Two pages do load code from other companies" becomes "One page", the "hosted by Tally" paragraph becomes "Our contact page carries no form", and Tally leaves the §4 processor list; ES mirrors all three. Section counts still match at 11/11 and 13/13 and the two processor lists are still equal, so the structure #44 verified is intact — but this changes what the policy commits to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)