### PR TITLE
fix(gates): the second review of #80 — one confusable constant, one dedupe rule, the decision it left unrecorded

### DIFF
--- a/scripts/check-copy-gate.mjs
+++ b/scripts/check-copy-gate.mjs
@@ -150,17 +150,18 @@ const CONFUSABLE = new RegExp(
     "\\u2160-\\u217F" + // Roman numeral forms
     "\\uFF21-\\uFF3A\\uFF41-\\uFF5A" + // fullwidth Latin
     "]|[\\u{1D400}-\\u{1D7FF}]", // Mathematical Alphanumeric Symbols
-  "u",
+  // GLOBAL because both readers below want every hit on a line, not the first;
+  // see the raw pass for what a first-hit-only reading mislabelled. Safe to share
+  // even though a /g regex carries lastIndex, because matchAll is the ONLY thing
+  // that consumes this: it clones the regex and leaves the original's lastIndex
+  // alone. Calling .test() or .exec() on it would make it stateful across files —
+  // don't.
+  "gu",
 );
-
-// The same regex, global, for the passes that want every hit on a line rather
-// than the first. Built from CONFUSABLE rather than written twice, because two
-// spellings of one class is the fault #57 named about the pattern list.
-const CONFUSABLE_ALL = new RegExp(CONFUSABLE.source, `${CONFUSABLE.flags}g`);
 
 // One dedupe-key shape for every pass in this file. NUL separates because it
 // cannot occur in a line number, a pattern index, or matched copy — and writing
-// it ONCE is the point: three call sites each spelling their own separator is how
+// it ONCE is the point: four call sites each spelling their own separator is how
 // the two halves of a dedupe drift apart while both still look right.
 const key = (...parts) => parts.join("\u0000");
 
@@ -323,13 +324,14 @@ for (const file of files) {
   // position in a derived string — the span map already points at the bytes an
   // author has to edit, and telling them where the decoded character "is" would
   // name a place that exists in no file.
-  const flagConfusable = (where, at, text, note) => {
+  // No `where`: every caller passed exactly `${file}:${at}`, which is judge's own
+  // default, so the argument only gave two places for one fact to disagree.
+  const flagConfusable = (at, text, note) => {
     const point = `U+${text.codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`;
     judge(
       at,
       `"${text}" (${point})${note}`,
       "not a Latin letter, but shaped like one — a homoglyph hides a gated word from every pattern above",
-      where,
     );
   };
 
@@ -339,21 +341,27 @@ for (const file of files) {
   // second as "[plain]" — a view finding, for a character sitting in plain sight
   // in the source. Naming the wrong cause is the fault the gates exist to remove,
   // and a label nobody can act on is the shape it takes here.
+  // Both passes dedupe on (line, character), and BOTH have to — the raw pass
+  // gained a `has` check the moment it went global. One line reads the same in
+  // both directions, so two occurrences of the SAME confusable on it produce two
+  // byte-identical error lines with no column to tell them apart: noise that
+  // reads as two defects. Two DIFFERENT confusables on one line still report
+  // twice, because they are two things to fix.
   const confusables = new Set();
+  const flagOnce = (line, text, note) => {
+    const id = key(line, text);
+    if (confusables.has(id)) return;
+    confusables.add(id);
+    flagConfusable(line, text, note);
+  };
+
   raw.forEach((line, i) => {
-    for (const m of line.matchAll(CONFUSABLE_ALL)) {
-      confusables.add(key(i + 1, m[0]));
-      flagConfusable(`${file}:${i + 1}`, i + 1, m[0], "");
-    }
+    for (const m of line.matchAll(CONFUSABLE)) flagOnce(i + 1, m[0], "");
   });
 
   for (const { name, text, map } of views) {
-    for (const m of text.matchAll(CONFUSABLE_ALL)) {
-      const line = lineAt(map[m.index]);
-      const id = key(line, m[0]);
-      if (confusables.has(id)) continue;
-      confusables.add(id);
-      flagConfusable(`${file}:${line}`, line, m[0], ` [${name}]`);
+    for (const m of text.matchAll(CONFUSABLE)) {
+      flagOnce(lineAt(map[m.index]), m[0], ` [${name}]`);
     }
   }
 }

--- a/scripts/copy-gate-normalise.mjs
+++ b/scripts/copy-gate-normalise.mjs
@@ -91,6 +91,18 @@
 //     design (#41), so there is no parser to borrow it from. #80's answer is that
 //     the class worth naming is the one an author reaches for — the space-like and
 //     the invisible — and NAMED holds those.
+//
+//     #80 asked a second half with it: does the SOURCE gate then need a
+//     non-fabricating "unknown reference blanked" view for NON-markup too? The
+//     answer is no, and it is recorded here because the behaviour alone does not
+//     say it. The reference views stay markupOnly, so a .ts file is read as plain
+//     text and escapes only. A "&" in a .ts string is not a reference: Astro
+//     escapes an interpolated string before it reaches the page, so `"insur&foo;
+//     ance"` renders with the ampersand intact and decoding it here would invent a
+//     word the reader never sees — a fabrication, in the gate that declines those.
+//     The case that WOULD publish it, a bundle assigning that string to innerHTML,
+//     is not a reference question at all; it is which file types get the markup
+//     views, which is #81.
 //   - "entities-blanked" is marked non-fabricating on the tag argument (removing a
 //     separator removes the gap), which holds for a reference a BROWSER also drops
 //     and not for one it renders literally: "insur&foo;ance" is "insur&foo;ance" on

--- a/scripts/copy-gate-normalise.test.mjs
+++ b/scripts/copy-gate-normalise.test.mjs
@@ -120,8 +120,10 @@ check("should stay quiet", MUST_NOT_FIRE, false);
 // came from slides every span after it, which is silent — the gate keeps working
 // and points at the wrong line. Astral characters are where that breaks, because
 // one code point is two UTF-16 units.
+let spanChecks = 0;
 for (const [name, raw] of [...MUST_FIRE, ...MUST_NOT_FIRE]) {
   for (const view of viewsOf(raw, { markup: true, includeFabricating: true })) {
+    spanChecks++;
     if (view.map.length !== view.text.length) {
       console.log(`FAIL  span map — ${name} [${view.name}]`);
       console.log(`      ${view.map.length} offsets for ${view.text.length} characters`);
@@ -137,6 +139,9 @@ for (const [name, raw] of [...MUST_FIRE, ...MUST_NOT_FIRE]) {
   }
 }
 
-const total = MUST_FIRE.length + MUST_NOT_FIRE.length;
+// Every list this file runs, the span-map sweep included — the sibling counts
+// PATHOLOGICAL the same way. A total that omits a check can only shrink when that
+// check is deleted, which is the one moment it needed to be loud.
+const total = MUST_FIRE.length + MUST_NOT_FIRE.length + spanChecks;
 console.log(`${failures ? "✗" : "✓"} copy-gate normaliser: ${total} controls, ${failures} failure${failures === 1 ? "" : "s"}`);
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Follow-up to #94 (merged as `9a3457f`). A second two-axis review of the whole #80 change — including `7141dbd`, the commit that answered the *first* review and had never itself been reviewed — found four more. All applied.

Both axes independently re-verified that the first review's fixes hold: no control bytes anywhere (the pre-fix blob had exactly 2), and the corrected comment about escaped confusables in comments is accurate as written, tested against all four comment shapes.

## The sharpest one is a regression the first fix introduced

Making the raw confusable pass global was right — a first-hit-only reading mislabelled a second same-line confusable as a view finding. But it went in **without the `has` check its sibling pass already had**, so two occurrences of the *same* confusable on one line printed two byte-identical error lines with no column to tell them apart:

```
src/pages/x.astro:4  "е" (U+0435) — not a Latin letter, but shaped like one …
src/pages/x.astro:4  "е" (U+0435) — not a Latin letter, but shaped like one …
```

Two defects on screen where there is one to fix. Both passes now dedupe on `(line, character)` through one `flagOnce()`. Pinned in both directions by fixture:

| arrangement | findings |
|---|---|
| two **identical** confusables, one line | 1 |
| two **different** confusables, one line | 2 |
| same confusable on **two** lines | 2 |

Fixing a mislabel by widening a reader, and leaving the reader's dedupe behind, is the same shape as the bug it fixed.

## Three more

- **`CONFUSABLE` had no remaining consumer** — it existed only so `CONFUSABLE_ALL` could be built from it, and the comment justifying the pair (*"rather than written twice, because two spellings of one class is the fault #57 named"*) described a duplication that no longer existed. A rationale outliving its reason. One `/gu` constant now, with the `lastIndex` caveat written down rather than left to be rediscovered: `matchAll` is the only consumer and clones the regex; `.test()`/`.exec()` on it would make it stateful across files.
- **`flagConfusable` took a dead `where`** that every caller filled with exactly `${file}:${at}` — `judge`'s own default. Two places for one fact to disagree, and the same smell the first review removed from the control file's `fires(raw, markup = true)`.
- **The control file's total omitted the span-map sweep**, which could fail without contributing to the count. **196 controls now, not 28** — the sweep was always the larger half and was invisible in the one line a reader looks at.

## Spec: the decision #80 left unrecorded

> *"Is a real entity table the answer, or does the source gate need a non-fabricating 'unknown reference blanked' view for non-markup too?"*

Only the first half was ever recorded. The second is now answered in the normaliser header — **no**, and why: a `&` in a `.ts` string is not a reference, because Astro escapes an interpolated string before it reaches the page, so decoding it would invent a word the reader never sees, in the gate that declines fabrication. The case that *would* publish it is a bundle assigning to `innerHTML`, which is not a reference question but #81's.

The behaviour was already right. The decision was missing from the record, and a decision only the code knows is one the next reader has to re-derive.

## Verified

- 196 normaliser controls and 95 pattern controls green.
- `npm run checks` green through all four PR-time gates.
- The source gate's output on the real tree **still byte-identical** to before #80 — none of this moved an allowlist entry.
- 11 fixture mutations through `check-copy-gate.mjs` itself, including the four confusable arrangements above and the #80 examples re-run to show nothing narrowed.
- No literal NUL and no literal invisible character in any touched file; all three still LF.

**Not run, which is an argument rather than a run:** `astro check`, `astro build`, and the dist gate against a real build — all need `@yeapptech/yeride-brand` and `NPM_TOKEN`. Nothing under `src/` or `public/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)