### PR TITLE
chore(ci): bump checks and drift workflows to actions@v7 (wayfinder #93)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,8 +53,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: EN/ES route parity + copy gate + env name parity

--- a/.github/workflows/fee-label-drift.yml
+++ b/.github/workflows/fee-label-drift.yml
@@ -25,8 +25,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 


### PR DESCRIPTION
Closes #93. Part of #30.

`deploy-all.yml` already runs `actions/checkout@v7` and `actions/setup-node@v7`. `checks.yml` and `fee-label-drift.yml` were still on `@v4`, which the runner currently **forces onto Node 24** with a deprecation warning — a warning today, a hard failure when the forcing stops. These are the two workflows whose value is that they run when nothing else does: the dependency-free PR gate (#41) and the daily drift schedule (#56), and a scheduled workflow that starts failing fails quietly.

Four lines, two files. Verified there is nothing to guard against:

- **`setup-node` v7** — cache-key outputs, ESM migration, dependency bumps, a dummy `NODE_AUTH_TOKEN` removal. The cache-behaviour risk #93 flagged does not bite: neither workflow sets `cache:`.
- **`checkout` v7** — the one behaviour change blocks fork checkout for `pull_request_target` and `workflow_run`. Neither workflow uses either trigger.

## Verification

- `npm run checks` green locally.
- **This PR's own `Build checks` run is the verification** for `checks.yml` — it must still finish in single-digit seconds with no `npm ci`.
- `fee-label-drift.yml` dispatched against this branch to confirm the v7 steps still reach `check-fee-labels.mjs` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
