### PR TITLE
About: /about and /es/about on the brand system (wayfinder #85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,15 @@ page declares its own `<html>`/`<head>`**, and no page carries inline header or 
 markup — `Header.astro` and `Footer.astro` have one caller each, `BaseLayout`. A navigation
 or footer change is therefore one edit, in one place.
 
-Redesigned routes keep the page file thin — `BaseLayout` plus one component that holds the
-whole body (`HomePage`, `DriversPage`, `RidersPage`, `FeeSchedule`, `FareEstimatePage`) — with
-the copy in `src/i18n/`. Follow that shape when adding a page. One page still awaits its
-redesign ticket — `about` — and sits on `BaseLayout` with its pre-redesign body inline; it is
-[#85](https://github.com/yeapptech/yeride-website/issues/85), blocked outside this repo on
-yeapptech/yeride-brand#22's authored ES identity paragraph.
+Every route keeps the page file thin — `BaseLayout` plus one component that holds the whole
+body (`HomePage`, `DriversPage`, `RidersPage`, `FeeSchedule`, `FareEstimatePage`,
+`LegalDocument`, `ContactPage`, `AboutPage`) — with the copy in `src/i18n/`. Follow that shape
+when adding a page. `about` was the last route still carrying its pre-redesign body and shipped
+on the shape with [#85](https://github.com/yeapptech/yeride-website/issues/85), once
+yeapptech/yeride-brand#22 landed the authored ES identity paragraph it was blocked on outside
+this repo. **No route is exempt any more, and gate 1's `PENDING` map is empty** — an entry
+there is now a claim that a route ships in one language, so add one only with the ticket that
+retires it.
 
 `/404` and `/redirect` are the two exceptions to "every route ships EN and ES": they are one
 file each, serving **both** languages, because GitHub Pages answers every missing path with a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ yeride-website/
 │   │   ├── FareEstimatePage.astro  # /fare-estimate — Maps + estimateFares
 │   │   ├── LegalDocument.astro     # /privacy-policy and /terms, both languages
 │   │   ├── ContactPage.astro
+│   │   ├── AboutPage.astro         # /about — prose page, ContactPage's measure
 │   │   ├── NotFoundPage.astro      # /404 — renders EN and ES at once
 │   │   ├── RedirectPage.astro      # /redirect — same
 │   │   ├── AvailabilityBlock.astro # Shared block (copy-map §2.1)
@@ -35,7 +36,7 @@ yeride-website/
 │   ├── i18n/                 # ALL copy, EN/ES, verbatim from docs/copy-map.md
 │   │   ├── homeCopy.ts  audienceCopy.ts  feesCopy.ts
 │   │   ├── fareEstimateCopy.ts  legalCopy.ts  utilityCopy.ts
-│   │   ├── formCopy.ts
+│   │   ├── aboutCopy.ts  formCopy.ts
 │   │   └── feeLabels.ts      # Site-authored names for backend charge/area/tier ids
 │   │
 │   ├── lib/
@@ -101,7 +102,7 @@ English one with **English slugs** (`/fees` → `/es/fees`, never `/es/tarifas`)
 | `src/pages/privacy-policy.astro` | `/privacy-policy` | `/es/privacy-policy` |
 | `src/pages/terms.astro` | `/terms` | `/es/terms` |
 | `src/pages/contact.astro` | `/contact` | `/es/contact` |
-| `src/pages/about.astro` | `/about` | pending (#85) |
+| `src/pages/about.astro` | `/about` | `/es/about` |
 | `src/pages/404.astro` | `/404` | **same file** |
 | `src/pages/redirect.astro` | `/redirect` | **same file** |
 
@@ -154,7 +155,8 @@ picks the mark that is legal on that ground, and `alternates`/`bilingual` are fo
 2. **Chrome** — `Header`, `Footer`. One caller each, `BaseLayout`; a nav change
    is one edit.
 3. **Body components** — one per route (`HomePage`, `DriversPage`, `RidersPage`,
-   `FeeSchedule`, `FareEstimatePage`, `LegalDocument`, `ContactPage`). Each takes
+   `FeeSchedule`, `FareEstimatePage`, `LegalDocument`, `ContactPage`,
+   `AboutPage`). Each takes
    `lang` **alone** and resolves its own copy from `src/i18n/`. A page that
    passes resolved copy down as a prop breaks the contract. `NotFoundPage` and
    `RedirectPage` take no props at all — they render both languages at once.

--- a/docs/components.md
+++ b/docs/components.md
@@ -491,6 +491,52 @@ If structured intake is wanted later, the shape to copy is **`PreRegistrationFor
 markup and per-field EN/ES copy in `src/i18n/`, posting to an endpoint YeRide owns — with a
 copy-map amendment giving §3.7 the field cells §2.2 has.
 
+### AboutPage
+
+The body of `/about` and `/es/about` (wayfinder #85).
+
+**Location:** `src/components/AboutPage.astro`
+
+**Props:**
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `lang` | `"en" \| "es"` | **yes** | Selects the copy |
+
+Copy: `src/i18n/aboutCopy.ts` (`aboutCopy`), verbatim from copy-map §3.6. Takes `lang` alone
+and resolves its own copy, the contract every page component here follows.
+
+A prose page, so it takes **`ContactPage`'s measure** rather than the audience pages' pillar
+stack — one paper ground, one `max-w-3xl` column, sections in exactly §3.6's slot order: H1,
+identity paragraph, mission, the four values, entity line. The four values are the only list,
+and they are a list in the copy map too.
+
+**The identity paragraph is the brand's paragraph quoted in part, and that is the whole point
+of the component.** `docs/identity.md` carries a "Who we are" paragraph in each language
+(the ES one authored by yeapptech/yeride-brand#22), marked verbatim-only — and **neither is
+usable whole**, because each states the suspended pass-through family as fact and each carries
+hard-coded money, so copy-map §5 fails the build on both, in both languages. §3.6 writes out
+the exact surviving text — the brand's own words, unedited and in its own order, **two spans
+omitted and nothing rewritten, resequenced or translated** — and this component takes it from
+§3.6 rather than from the brand doc. The argument for each omission is on `aboutCopy.ts`:
+
+- **The fee sentence** returns when [#48](https://github.com/yeapptech/yeride-website/issues/48)
+  lands. That is an edit to `aboutCopy.ts` alone — do not restore it anywhere else.
+- **The origin sentence** carries hard-coded money (copy-map §0.4). It was cut rather than
+  blessed with a `copy-gate-allow`, because a pragma buys a permanent hole in the one rule
+  keeping invented figures off this site.
+
+Two things a reader might otherwise take for defects. §3.6 sets the paragraph in markdown with
+a **bold lead sentence and italicised word mentions**; those are the document's formatting, not
+copy — this site's copy modules are plain strings everywhere and nothing renders `set:html`, so
+the emphasis is dropped and the words are unchanged. And the **entity line repeats** the
+paragraph's closing sentence in fuller form: §3.6 specifies both slots, they sit four sections
+apart, and with the origin sentence cut the entity line is the only surviving mention of
+Hernando Sierra.
+
+`/about` is linked from the **footer only** — copy-map §1.2, and §1.1's header has no About
+slot — so `Footer.astro` already carried it in both languages and shipping this page needed no
+nav change.
+
 ## Page-Specific Components
 
 ### Homepage (index.astro)

--- a/scripts/check-route-parity.mjs
+++ b/scripts/check-route-parity.mjs
@@ -19,12 +19,10 @@ const EXEMPT = new Set(["404", "redirect"]);
 //
 // The list cannot go stale: an entry whose twin now exists, or whose EN page has
 // gone, fails the check.
-const PENDING = {
-  // #39 split /about out to #85 on 2026-08-04: it is the only route left whose
-  // ES twin is blocked OUTSIDE this repo, on yeapptech/yeride-brand#22's
-  // authored ES identity paragraph. Nothing here can retire it.
-  about: "#85 — the identity page",
-};
+// Empty since 2026-08-10 (#85): /about was the last entry, and it shipped with
+// its twin once yeapptech/yeride-brand#22 landed the authored ES identity
+// paragraph. #42's precondition is met — keep it that way.
+const PENDING = {};
 
 function walk(dir) {
   return readdirSync(dir).flatMap((entry) => {

--- a/src/components/AboutPage.astro
+++ b/src/components/AboutPage.astro
@@ -1,0 +1,73 @@
+---
+// /about and /es/about (wayfinder #85). Copy VERBATIM from docs/copy-map.md
+// §3.6; §4's title and meta description sit on the page files.
+//
+// Takes `lang` alone and resolves its own copy from src/i18n — the contract
+// docs/components.md sets for page components.
+//
+// A prose page, so it takes ContactPage's measure rather than the audience
+// pages' pillar stack: one paper ground, one column, section order exactly as
+// §3.6 lists its slots — H1, identity paragraph, mission, the four values,
+// entity line. The four values are the only list, and they are a list in the
+// copy map too.
+//
+// Why this page is smaller than the brand paragraph it quotes: two spans are
+// omitted from `identity`, and the reasons live on `aboutCopy.ts`. The fee
+// sentence returns when #48 lands; restoring it is an edit to that file alone.
+import { aboutCopy } from "../i18n/aboutCopy";
+import type { Lang } from "../i18n/feesCopy";
+
+export interface Props {
+  lang: Lang;
+}
+const { lang } = Astro.props;
+const t = aboutCopy[lang];
+---
+
+<main class="bg-paper">
+  <div class="mx-auto w-full max-w-3xl px-5 pb-20 pt-10 sm:px-6 md:pb-28 md:pt-16">
+    <h1
+      class="font-extrabold tracking-headline text-[2rem] leading-[1.06] text-ink sm:text-[2.5rem]"
+    >
+      {t.h1}
+    </h1>
+    <p class="mt-6 text-[17px] leading-relaxed text-ink/80 sm:text-[19px]">
+      {t.identity}
+    </p>
+
+    <section class="mt-12 border-t border-ink/10 pt-10 md:mt-16">
+      <h2
+        class="font-extrabold tracking-headline text-[1.5rem] leading-[1.15] text-ink sm:text-[1.75rem]"
+      >
+        {t.missionH2}
+      </h2>
+      <p class="mt-4 text-[17px] leading-relaxed text-ink/80">{t.mission}</p>
+    </section>
+
+    <section class="mt-12 border-t border-ink/10 pt-10 md:mt-16">
+      <h2
+        class="font-extrabold tracking-headline text-[1.5rem] leading-[1.15] text-ink sm:text-[1.75rem]"
+      >
+        {t.valuesH2}
+      </h2>
+      <ul class="mt-6 space-y-4">
+        {
+          t.values.map((value) => (
+            <li class="flex gap-3 text-[17px] leading-relaxed text-ink/80">
+              {/* a dot, not a dash — every value already opens with an em dash */}
+              <span
+                aria-hidden="true"
+                class="mt-[0.6em] h-1.5 w-1.5 shrink-0 rounded-full bg-cab-yellow"
+              />
+              <span>{value}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <p class="mt-14 border-t border-ink/10 pt-8 text-[15px] text-ink/60 md:mt-20">
+      {t.entity}
+    </p>
+  </div>
+</main>

--- a/src/i18n/aboutCopy.ts
+++ b/src/i18n/aboutCopy.ts
@@ -1,0 +1,69 @@
+// /about and /es/about copy — VERBATIM from docs/copy-map.md §3.6 (wayfinder
+// #85). Do not reword, re-case, or re-punctuate. §4's title and meta
+// description sit on the page files, as they do everywhere.
+//
+// `identity` is the brand's own paragraph from `docs/identity.md` "Who we are",
+// both languages authored (yeride-brand#22, `fe5be01`), with TWO SPANS OMITTED
+// and nothing else touched — no rewriting, no resequencing, no translating.
+// §3.6 writes out the exact surviving text and says the build takes it from
+// there rather than from the brand doc, so this file quotes §3.6, not identity.md.
+//
+// The two omissions are not editorial. §5 fails the build on both, in both
+// languages, because neither is true today:
+//   - the fee sentence states the suspended pass-through family as fact —
+//     YeRide carries no insurance and Stripe bills the driver's own connected
+//     account directly (§3.4, #47). It returns when #48 lands.
+//   - the origin sentence carries hard-coded money, which §5 admits nowhere on
+//     this site (§0.4). Cut rather than pragma'd: a pragma buys a permanent
+//     hole in the one rule keeping invented figures off the site, and the
+//     origin beat is the one an About page can most afford to lose.
+// What survives carries the promise, the name and the entity, plus the
+// no-commission line, and reads as one paragraph without the other two.
+//
+// §3.6 sets the identity paragraph in markdown with a bold lead sentence and
+// italicised word mentions. Those are the DOCUMENT's formatting, not copy: this
+// site's copy modules are plain strings everywhere and nothing renders
+// `set:html`, so the emphasis is dropped and the words are unchanged.
+//
+// `entity` restates the entity in fuller form than the paragraph's closing
+// sentence — it is the only place Hernando Sierra survives, the origin sentence
+// having been cut — and runs as a colophon at the foot of the page, four
+// sections below the paragraph. §3.6 specifies both slots.
+import type { Lang } from "./feesCopy";
+
+export const aboutCopy = {
+  en: {
+    h1: "About YeRide",
+    identity:
+      'YeRide is a rideshare platform built in South Florida on a simple promise: drivers keep what they earn, and riders pay what the ride is worth. YeRide takes no commission. The name says the rest: "ye" is the old word for you. YeRide is your ride — whichever seat you\'re in. YeRide is built by YeAPP TECH LLC, a Florida software company.',
+    missionH2: "Our mission",
+    mission:
+      "Make ridesharing fair: drivers keep what they earn, riders pay what the ride is worth.",
+    valuesH2: "What we hold to",
+    values: [
+      "Transparency — every fee flat, published, and visible.",
+      "Fairness to both sides — never grow one side's number by squeezing the other.",
+      "Respect for the people doing the work — drivers are customers, not costs.",
+      "Earn by efficiency, not extraction.",
+    ],
+    entity:
+      "YeRide is built by YeAPP TECH LLC, a Florida software company founded by Hernando Sierra.",
+  },
+  es: {
+    h1: "Sobre YeRide",
+    identity:
+      'YeRide es una plataforma de viajes hecha en el Sur de la Florida sobre una promesa sencilla: lo que el conductor gana es suyo, y el pasajero paga lo justo. YeRide no cobra comisión. El nombre dice el resto: "ye" es el you del inglés antiguo — el "tú" que se le dice a todos. YeRide es tu viaje — vayas en el asiento que vayas. YeRide la construye YeAPP TECH LLC, una compañía de software de la Florida.',
+    missionH2: "Nuestra misión",
+    mission:
+      "Hacer justo el transporte compartido: que quien maneja se quede con lo que gana y quien viaja pague lo justo.",
+    valuesH2: "En qué nos sostenemos",
+    values: [
+      "Transparencia — cada cargo fijo, publicado y a la vista.",
+      "Justicia para ambos lados — nunca subir el número de un lado apretando al otro.",
+      "Respeto por quien hace el trabajo — quien maneja es cliente, no un costo.",
+      "Ganar por eficiencia, no por extracción.",
+    ],
+    entity:
+      "YeRide es un producto de YeAPP TECH LLC, una empresa de software de la Florida fundada por Hernando Sierra.",
+  },
+} satisfies Record<Lang, unknown>;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,35 +1,13 @@
 ---
-// Body content below is pre-redesign — the brand rebuild of this page is
-// ticket #85, split out of #39 because /es/about is blocked outside this repo
-// on yeapptech/yeride-brand#22's authored ES identity paragraph. EN and ES ship
-// together (copy-map §0.1), so this page waits for it in both languages.
+// /about (wayfinder #85). Title and meta description per docs/copy-map.md §4.
 import BaseLayout from "../layouts/BaseLayout.astro";
+import AboutPage from "../components/AboutPage.astro";
 ---
 
-<BaseLayout title="About Us - YeRide">
-  <main>
-    <section class="bg-gradient-to-r from-blue-500 to-blue-700 text-white py-20">
-      <div class="container mx-auto px-4 text-center">
-        <h1 class="text-4xl md:text-5xl font-bold mb-4">
-          About YeRide
-        </h1>
-        <p class="text-xl mb-8 max-w-2xl mx-auto">
-          A community-driven movement dedicated to making transportation fair and equitable.
-        </p>
-      </div>
-    </section>
-
-    <section class="py-16 bg-white">
-      <div class="container mx-auto px-4">
-        <div class="max-w-3xl mx-auto">
-          <p class="text-lg mb-6 text-gray-700 leading-relaxed">
-            At YeRide, we're not just a ridesharing app; we're a community-driven
-            movement dedicated to making transportation fair and equitable.
-            Our mission is to connect riders and drivers directly, eliminating
-            the middleman, and fostering a local community of happy riders and drivers.
-          </p>
-        </div>
-      </div>
-    </section>
-  </main>
+<BaseLayout
+  title="About YeRide | YeRide"
+  description="Why YeRide exists, who built it, and the four things it holds to."
+  lang="en"
+>
+  <AboutPage lang="en" />
 </BaseLayout>

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -1,0 +1,13 @@
+---
+// /es/about (wayfinder #85). Title and meta description per docs/copy-map.md §4.
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import AboutPage from "../../components/AboutPage.astro";
+---
+
+<BaseLayout
+  title="Sobre YeRide | YeRide"
+  description="Por qué existe YeRide, quién lo construyó y las cuatro cosas en las que se sostiene."
+  lang="es"
+>
+  <AboutPage lang="es" />
+</BaseLayout>


### PR DESCRIPTION
Resolves #85 (wayfinder map #30).

`/about` was the last page still carrying its pre-redesign body, and the only route left in `check-route-parity.mjs`'s `PENDING` list. It ships now in both languages.

## What landed

- **`src/i18n/aboutCopy.ts`** — EN/ES copy verbatim from `docs/copy-map.md` §3.6.
- **`src/components/AboutPage.astro`** — one body component, `lang` prop, paper ground, one column. Takes `ContactPage`'s measure rather than the audience pages' pillar stack, because this is a prose page. Section order is exactly §3.6's slot order.
- **`src/pages/about.astro`** (rewritten) and **`src/pages/es/about.astro`** (new) — thin `BaseLayout` pages, §4's titles and meta descriptions.
- **`scripts/check-route-parity.mjs`** — `PENDING` is now empty. #42's "PENDING empty" precondition is met.

## The blocker cleared today

[yeapptech/yeride-brand#22](https://github.com/yeapptech/yeride-brand/issues/22) landed the **authored** ES identity paragraph in `fe5be01`, so both languages exist and EN/ES can ship together (§0.1). This was the only ticket on the map blocked outside this repo.

## The identity paragraph is quoted in part, not whole

Neither language is usable whole. §3.6 (amended today on `copy-map/en-es`, `62f9eb8`) writes out the surviving text — **the brand's own words, unedited and in its own order, with two spans omitted and nothing rewritten, resequenced or translated** — and says the build takes it from §3.6 rather than from the brand doc. Both omissions are forced by §5, not preferences:

- **The fee sentence** states the suspended pass-through family as fact. YeRide carries no insurance and card processing is not a YeRide pass-through — Stripe bills the driver's own connected account (§3.4, #47). §5 fails the build on every word it turns on. **It returns when #48 lands.**
- **The origin sentence** carries hard-coded money, which §5 admits nowhere on this site (§0.4). Cut rather than pragma'd: a `copy-gate-allow` would be within precedent, but it buys a permanent hole in the one rule keeping invented figures off the site, and the origin beat is the one an About page can most afford to lose.

What survives carries three of the paragraph's five beats — the promise, the name, the entity — plus the no-commission line, and reads as one paragraph. The reasoning is written onto `aboutCopy.ts`, so restoring the fee sentence for #48 is an edit to that one file.

## Two smaller judgment calls, both recorded in the code

- **Emphasis dropped.** §3.6 sets the paragraph in markdown with a bold lead sentence and italicised word mentions. That is the document's formatting, not copy: this site's copy modules are plain strings everywhere and nothing renders `set:html`. The words are unchanged.
- **The entity line repeats.** §3.6 specifies both the identity paragraph (which closes on the entity) and a standalone entity line (which adds "founded by Hernando Sierra"). Both ship as specified — they sit four sections apart, and with the origin sentence cut, the entity line is the only place Hernando Sierra survives.

**Nav needed no change:** §1.2 puts About in the footer only, and `Footer.astro` already links it in both languages.

## Verification

`npm run build` green end to end in a clean worktree — the six control sets, then all seven gates:

- 122 + 310 + 24 + 19 + 36 copy-gate controls and 31 `serviceArea` checks, 0 failures
- route parity: 11 EN / 9 ES pages, `PENDING` empty
- copy gate: 49 files, no new allowances
- `astro check`: 0 errors, 0 warnings
- dist copy gate: 32 files, no new allowances

Rendered output for both routes was read back out of `dist/` and matches §3.6 and §4 word for word, with `hreflang` pairing `/about` ⇄ `/es/about`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
